### PR TITLE
feat: final rename_observations and tests

### DIFF
--- a/src/spac/transformations.py
+++ b/src/spac/transformations.py
@@ -145,7 +145,6 @@ def batch_normalize(adata, obs, layer, method="median", log=False):
 def rename_observations(adata, src_observation, dest_observation, mappings):
     """
     Rename observations in an AnnData object based on a provided dictionary.
-    
     This function creates a new observation column.
 
     Parameters
@@ -180,7 +179,8 @@ def rename_observations(adata, src_observation, dest_observation, mappings):
     ...     "37": "group_5",
     ... }
     >>> dest_observation = "renamed_observations"
-    >>> adata = rename_observations(adata, src_observation, dest_observation, mappings)
+    >>> adata = rename_observations(
+    ...     adata, src_observation, dest_observation, mappings)
     """
 
     # Check if the source observation exists in the AnnData object
@@ -198,8 +198,9 @@ def rename_observations(adata, src_observation, dest_observation, mappings):
         type(unique_values[0])(key): value
         for key, value in mappings.items()
     }
-    
-    # Check if all keys in mappings match the unique values in the source observation
+   
+    # Check if all keys in mappings match the unique values in the
+    # source observation
     if not all(key in unique_values for key in mappings.keys()):
         raise ValueError(
             "All keys in the mappings dictionary should match the unique "
@@ -222,4 +223,3 @@ def rename_observations(adata, src_observation, dest_observation, mappings):
     )
 
     return adata
-

--- a/src/spac/transformations.py
+++ b/src/spac/transformations.py
@@ -198,7 +198,7 @@ def rename_observations(adata, src_observation, dest_observation, mappings):
         type(unique_values[0])(key): value
         for key, value in mappings.items()
     }
-   
+
     # Check if all keys in mappings match the unique values in the
     # source observation
     if not all(key in unique_values for key in mappings.keys()):

--- a/src/spac/transformations.py
+++ b/src/spac/transformations.py
@@ -141,65 +141,85 @@ def batch_normalize(adata, obs, layer, method="median", log=False):
     new_df = pd.concat(new_df_list)
     adata.layers[layer] = new_df
 
-def rename_clustering(adata, column, new_phenotypes, new_column_name="renamed_clusters"):
+
+def rename_observations(adata, src_observation, dest_observation, mappings):
     """
-    Rename and group clusters in an AnnData object based on the provided
-    dictionary, keeping the original observation column.
+    Rename observations in an AnnData object based on a provided dictionary.
+    
+    This function creates a new observation column.
 
     Parameters
     ----------
     adata : anndata.AnnData
         The AnnData object.
-    column : str
-        Name of the column in adata.obs containing the original cluster labels.
-    new_phenotypes : dict
-        A dictionary mapping the original cluster names to the new phenotype names.
-    new_column_name : str, optional, default: "renamed_clusters"
+    src_observation : str
+        Name of the column in adata.obs containing the original
+        observation labels.
+    dest_observation : str
         The name of the new column to be created in the AnnData object
-        containing the renamed cluster labels.
+        containing the renamed observation labels.
+    mappings : dict
+        A dictionary mapping the original observation labels to
+        the new labels.
 
     Returns
     -------
     adata : anndata.AnnData
-        The updated Anndata object with the new column containing the renamed
-        cluster labels.
-    """
-    
-    """
-    # An example to call the function:
-    adata = your_anndata_object
-    column = "phenograph"
-    new_phenotypes = {
-        "0": "group_8",
-        "1": "group_2",
-        "2": "group_6",
-        # ...
-        "37": "group_5",
-    }
-    new_column_name = "renamed_clusters"
+        The updated Anndata object with the new column containing the
+        renamed observation labels.
 
-    adata = rename_clustering(adata, column, new_phenotypes, new_column_name)
+    Examples
+    --------
+    >>> adata = your_anndata_object
+    >>> src_observation = "phenograph"
+    >>> mappings = {
+    ...     "0": "group_8",
+    ...     "1": "group_2",
+    ...     "2": "group_6",
+    ...     # ...
+    ...     "37": "group_5",
+    ... }
+    >>> dest_observation = "renamed_observations"
+    >>> adata = rename_observations(adata, src_observation, dest_observation, mappings)
     """
 
-    # Get the unique values of the observation column
-    unique_values = adata.obs[column].unique()
-
-    # Convert the keys in new_phenotypes to the same data type as the unique
-    # values in the observation column
-    new_phenotypes = {
-        type(unique_values[0])(key): value for key, value in new_phenotypes.items()
-    }
-
-    # Check if all keys in new_phenotypes are present in the unique values of
-    # the observation column
-    if not all(key in unique_values for key in new_phenotypes.keys()):
+    # Check if the source observation exists in the AnnData object
+    if src_observation not in adata.obs.columns:
         raise ValueError(
-            "All keys in the new_phenotypes dictionary should match the unique "
-            "values in the observation column."
+            f"Source observation '{src_observation}' not found in the "
+            "AnnData object."
         )
+
+    # Get the unique values of the source observation
+    unique_values = adata.obs[src_observation].unique()
+
+    # Convert the keys in mappings to the same data type as the unique values
+    mappings = {
+        type(unique_values[0])(key): value
+        for key, value in mappings.items()
+    }
     
-    # Create a new column in adata.obs with the updated cluster names
-    adata.obs[new_column_name] = adata.obs[column].map(new_phenotypes)\
-        .fillna(adata.obs[column]).astype("category")
+    # Check if all keys in mappings match the unique values in the source observation
+    if not all(key in unique_values for key in mappings.keys()):
+        raise ValueError(
+            "All keys in the mappings dictionary should match the unique "
+            "values in the source observation."
+        )
+
+    # Check if the destination observation already exists in the AnnData object
+    if dest_observation in adata.obs.columns:
+        raise ValueError(
+            f"Destination observation '{dest_observation}' already exists "
+            "in the AnnData object."
+        )
+
+    # Create a new column in adata.obs with the updated observation labels
+    adata.obs[dest_observation] = (
+        adata.obs[src_observation]
+        .map(mappings)
+        .fillna(adata.obs[src_observation])
+        .astype("category")
+    )
 
     return adata
+

--- a/tests/test_transformations/test_rename_observations.py
+++ b/tests/test_transformations/test_rename_observations.py
@@ -7,7 +7,6 @@ import pandas as pd
 import numpy as np
 
 sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "/../src")
-
 from spac.transformations import rename_observations
 
 
@@ -39,19 +38,21 @@ class TestRenameObservations(unittest.TestCase):
         """Test rename_observations with a missing source observation."""
         with self.assertRaises(ValueError):
             rename_observations(
-                self.adata, 
-                "missing_src", 
-                "new_dest", 
+                self.adata,
+                "missing_src",
+                "new_dest",
                 {"0": "group_8"}
             )
 
     def test_existing_dest_observation(self):
-        """Test rename_observations with an existing destination observation."""
+        """
+        Test rename_observations with an existing destination observation.
+        """
         with self.assertRaises(ValueError):
             rename_observations(
-                self.adata, 
-                "phenograph", 
-                "phenograph", 
+                self.adata,
+                "phenograph",
+                "phenograph",
                 {"0": "group_8"}
             )
 
@@ -59,9 +60,9 @@ class TestRenameObservations(unittest.TestCase):
         """Test rename_observations with invalid mappings."""
         with self.assertRaises(ValueError):
             rename_observations(
-                self.adata, 
-                "phenograph", 
-                "new_dest", 
+                self.adata,
+                "phenograph",
+                "new_dest",
                 {"5": "group_8"}
             )
 
@@ -94,7 +95,10 @@ class TestRenameObservations(unittest.TestCase):
             adata, "original_phenotype", "renamed_clusters", new_phenotypes
         )
         self.assertTrue(
-            all(adata.obs["renamed_clusters"] == ["group_0", "group_1", "group_0"])
+            all(
+                adata.obs["renamed_clusters"] ==
+                ["group_0", "group_1", "group_0"]
+            )
         )
 
     def create_test_anndata(self, n_cells=100, n_genes=10):
@@ -122,9 +126,12 @@ class TestRenameObservations(unittest.TestCase):
         self.assertIn("renamed_clusters", adata.obs.columns)
 
         expected_cluster_names = ["group_1", "group_2", "group_3"]
+        renamed_clusters_set = set(adata.obs["renamed_clusters"])
+        expected_clusters_set = set(expected_cluster_names)
         self.assertTrue(
-            set(adata.obs["renamed_clusters"]).issubset(set(expected_cluster_names))
+            renamed_clusters_set.issubset(expected_clusters_set)
         )
+
 
         new_phenotypes = {
             "0": "group_1",
@@ -151,11 +158,8 @@ class TestRenameObservations(unittest.TestCase):
             adata, "original_phenotype", "renamed_clusters", new_phenotypes
         )
 
-        self.assertTrue(
-            all(adata.obs["renamed_clusters"] == ["group_0", "group_0", "group_0"])
-        )
-
+        renamed_clusters = adata.obs["renamed_clusters"]
+        self.assertTrue(all(renamed_clusters == ["group_0", "group_0", "group_0"]))
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/tests/test_transformations/test_rename_observations.py
+++ b/tests/test_transformations/test_rename_observations.py
@@ -132,7 +132,6 @@ class TestRenameObservations(unittest.TestCase):
             renamed_clusters_set.issubset(expected_clusters_set)
         )
 
-
         new_phenotypes = {
             "0": "group_1",
             "1": "group_2",
@@ -159,7 +158,10 @@ class TestRenameObservations(unittest.TestCase):
         )
 
         renamed_clusters = adata.obs["renamed_clusters"]
-        self.assertTrue(all(renamed_clusters == ["group_0", "group_0", "group_0"]))
+        self.assertTrue(
+            all(renamed_clusters == ["group_0", "group_0", "group_0"])
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_transformations/test_rename_observations.py
+++ b/tests/test_transformations/test_rename_observations.py
@@ -1,0 +1,161 @@
+import os
+import sys
+import unittest
+
+import anndata
+import pandas as pd
+import numpy as np
+
+sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "/../src")
+
+from spac.transformations import rename_observations
+
+
+class TestRenameObservations(unittest.TestCase):
+    def setUp(self):
+        """Set up a sample AnnData object for testing."""
+        obs = pd.DataFrame(
+            {"phenograph": ["0", "1", "0", "2", "1", "2"]},
+            index=["cell_1", "cell_2", "cell_3", "cell_4", "cell_5", "cell_6"]
+        )
+        self.adata = anndata.AnnData(X=np.random.randn(6, 3), obs=obs)
+
+    def test_typical_case(self):
+        """Test rename_observations with typical parameters."""
+        mappings = {"0": "group_8", "1": "group_2", "2": "group_6"}
+        dest_observation = "renamed_observations"
+        result = rename_observations(
+            self.adata, "phenograph", dest_observation, mappings
+        )
+        expected = pd.Series(
+            ["group_8", "group_2", "group_8", "group_6", "group_2", "group_6"],
+            index=self.adata.obs.index,
+            name=dest_observation,
+            dtype="category"
+        )
+        pd.testing.assert_series_equal(result.obs[dest_observation], expected)
+
+    def test_missing_src_observation(self):
+        """Test rename_observations with a missing source observation."""
+        with self.assertRaises(ValueError):
+            rename_observations(
+                self.adata, 
+                "missing_src", 
+                "new_dest", 
+                {"0": "group_8"}
+            )
+
+    def test_existing_dest_observation(self):
+        """Test rename_observations with an existing destination observation."""
+        with self.assertRaises(ValueError):
+            rename_observations(
+                self.adata, 
+                "phenograph", 
+                "phenograph", 
+                {"0": "group_8"}
+            )
+
+    def test_invalid_mappings(self):
+        """Test rename_observations with invalid mappings."""
+        with self.assertRaises(ValueError):
+            rename_observations(
+                self.adata, 
+                "phenograph", 
+                "new_dest", 
+                {"5": "group_8"}
+            )
+
+    def test_partial_mappings(self):
+        """Test rename_observations with partial mappings."""
+        mappings = {"0": "group_8", "1": "group_2"}
+        dest_observation = "renamed_observations"
+        result = rename_observations(
+            self.adata, "phenograph", dest_observation, mappings
+        )
+        expected = pd.Series(
+            ["group_8", "group_2", "group_8", "2", "group_2", "2"],
+            index=self.adata.obs.index,
+            name=dest_observation,
+            dtype="category"
+        )
+        pd.testing.assert_series_equal(result.obs[dest_observation], expected)
+
+    def test_rename_observations_basic(self):
+        """Test basic functionality of rename_observations."""
+        data_matrix = np.random.rand(3, 4)
+        obs = pd.DataFrame(index=["cell_1", "cell_2", "cell_3"])
+        obs["original_phenotype"] = ["A", "B", "A"]
+
+        adata = anndata.AnnData(X=data_matrix, obs=obs)
+
+        new_phenotypes = {"A": "group_0", "B": "group_1"}
+
+        adata = rename_observations(
+            adata, "original_phenotype", "renamed_clusters", new_phenotypes
+        )
+        self.assertTrue(
+            all(adata.obs["renamed_clusters"] == ["group_0", "group_1", "group_0"])
+        )
+
+    def create_test_anndata(self, n_cells=100, n_genes=10):
+        """Create a test AnnData object with random gene expressions."""
+        data_matrix = np.random.rand(n_cells, n_genes)
+        obs = pd.DataFrame(index=np.arange(n_cells))
+        obs['phenograph'] = np.random.choice([0, 1, 2], size=n_cells)
+        var = pd.DataFrame(index=np.arange(n_genes))
+        return anndata.AnnData(X=data_matrix, obs=obs, var=var)
+
+    def test_rename_observations(self):
+        """Test rename_observations with generated AnnData object."""
+        test_adata = self.create_test_anndata()
+
+        new_phenotypes = {
+            "0": "group_1",
+            "1": "group_2",
+            "2": "group_3",
+        }
+
+        adata = rename_observations(
+            test_adata, "phenograph", "renamed_clusters", new_phenotypes
+        )
+
+        self.assertIn("renamed_clusters", adata.obs.columns)
+
+        expected_cluster_names = ["group_1", "group_2", "group_3"]
+        self.assertTrue(
+            set(adata.obs["renamed_clusters"]).issubset(set(expected_cluster_names))
+        )
+
+        new_phenotypes = {
+            "0": "group_1",
+            "1": "group_2",
+            "3": "group_3",
+        }
+
+        with self.assertRaises(ValueError):
+            adata = rename_observations(
+                test_adata, "phenograph", "renamed_clusters", new_phenotypes
+            )
+
+    def test_multiple_observations_to_one_group(self):
+        """Test case where two observations are mapped to one group."""
+        data_matrix = np.random.rand(3, 4)
+        obs = pd.DataFrame(index=["cell_1", "cell_2", "cell_3"])
+        obs["original_phenotype"] = ["A", "B", "A"]
+
+        adata = anndata.AnnData(X=data_matrix, obs=obs)
+
+        new_phenotypes = {"A": "group_0", "B": "group_0"}
+
+        adata = rename_observations(
+            adata, "original_phenotype", "renamed_clusters", new_phenotypes
+        )
+
+        self.assertTrue(
+            all(adata.obs["renamed_clusters"] == ["group_0", "group_0", "group_0"])
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
This pull request includes the refactored rename_observations function and the corresponding tests for your review. 
Notes for the results of "Use flake8 to check code":
1. "test_rename_observations.py:10:1: E402 module level import not at top of file"
sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "/../src")
from spac.transformations import rename_observations
* import line should follow sys.path.append().

2. "transformations.py:1:1: F401 're' imported but unused
transformations.py:2:1: F401 'seaborn' imported but unused
transformations.py:6:1: F401 'anndata as ad' imported but unused
transformations.py:8:1: F401 'matplotlib.pyplot as plt' imported but unused
transformations.py:9:1: F401 'sklearn.preprocessing.MinMaxScaler' imported but unused"

* I will modify these lines when I work on other functions within transformations.py

Please let me know if any changes or updates are required.
