### PR TITLE
Add error handling utils for anndata checks

### DIFF
--- a/src/spac/utils.py
+++ b/src/spac/utils.py
@@ -1,4 +1,5 @@
 import re
+import anndata as ad
 
 
 def regex_search_list(
@@ -70,3 +71,86 @@ def regex_search_list(
     all_results = list(all_results)
 
     return all_results
+
+
+def anndata_checks(
+        adata,
+        layers=None,
+        obs=None,
+        features=None):
+    """
+    Perform common error checks for anndata related objects.
+
+    Parameters
+    ----------
+    adata : anndata.AnnData
+        The AnnData object to be checked.
+
+    layers : str or list of str, optional
+        The layer(s) to check for existence in adata.layers.keys().
+
+    obs : str or list of str, optional
+        The observation(s) to check for existence in adata.obs.
+
+    features : str or list of str, optional
+        The feature(s) to check for existence in adata.var_names.
+
+    Raises
+    ------
+    TypeError
+        If adata is not an instance of anndata.AnnData.
+
+    ValueError
+        If any of the specified layers, observations, or features do not exist.
+
+    Example
+    -------
+    >>> import anndata as ad
+    >>> adata = ad.AnnData(...)
+    >>> anndata_checks(
+        adata,
+        layers=['layer1', 'layer2'],
+        obs=['obs1', 'obs2'],
+        features=['feature1', 'feature2'])
+    """
+
+    # Check if adata is an instance of anndata.AnnData
+    if not isinstance(adata, ad.AnnData):
+        raise TypeError("Input 'adata' should be \
+                        an instance of anndata.AnnData.")
+
+    # Check for specified layers existence
+    if layers is not None:
+        if isinstance(layers, str):
+            layers = [layers]
+        elif not isinstance(layers, list):
+            raise ValueError("The 'layers' parameter should be \
+                             a string or a list of strings.")
+        for layer in layers:
+            if layer not in adata.layers.keys():
+                raise ValueError(f"The table '{layer}' does not exist \
+                                 in the provided dataset.")
+
+    # Check for specified observations existence
+    if obs is not None:
+        if isinstance(obs, str):
+            obs = [obs]
+        elif not isinstance(obs, list):
+            raise ValueError("The 'obs' parameter should be \
+                             a string or a list of strings.")
+        for observation in obs:
+            if observation not in adata.obs:
+                raise ValueError(f"The observation '{observation}' \
+                                 does not exist in the provided dataset.")
+
+    # Check for specified features existence
+    if features is not None:
+        if isinstance(features, str):
+            features = [features]
+        elif not isinstance(features, list):
+            raise ValueError("The 'features' parameter should be a \
+                             string or a list of strings.")
+        for feature in features:
+            if feature not in adata.var_names:
+                raise ValueError(f"The feature '{feature}' does not exist \
+                                 in the provided dataset.")

--- a/src/spac/utils.py
+++ b/src/spac/utils.py
@@ -116,8 +116,11 @@ def anndata_checks(
 
     # Check if adata is an instance of anndata.AnnData
     if not isinstance(adata, ad.AnnData):
-        raise TypeError("Input 'adata' should be \
-                        an instance of anndata.AnnData.")
+        raise TypeError(
+            "Input dataset should be "
+            "an instance of anndata.AnnData, "
+            "please check the input dataset source."
+            )
 
     # Check for specified layers existence
     if layers is not None:
@@ -126,10 +129,16 @@ def anndata_checks(
         elif not isinstance(layers, list):
             raise ValueError("The 'layers' parameter should be \
                              a string or a list of strings.")
+        layer_list = list(adata.layers.keys())
         for layer in layers:
-            if layer not in adata.layers.keys():
-                raise ValueError(f"The table '{layer}' does not exist \
-                                 in the provided dataset.")
+            if layer not in layer_list:
+                existing_layer_str = "\n".join(layer_list)
+                raise ValueError(
+                    f"The table '{layer}' "
+                    "does not exist in the provided dataset.\n"
+                    "Existing tables are:\n"
+                    f"{existing_layer_str}"
+                )
 
     # Check for specified observations existence
     if obs is not None:
@@ -138,10 +147,16 @@ def anndata_checks(
         elif not isinstance(obs, list):
             raise ValueError("The 'obs' parameter should be \
                              a string or a list of strings.")
+        existing_obs = adata.obs.columns.to_list()
         for observation in obs:
-            if observation not in adata.obs:
-                raise ValueError(f"The observation '{observation}' \
-                                 does not exist in the provided dataset.")
+            if observation not in existing_obs:
+                existing_obs_str = "\n".join(existing_obs)
+                raise ValueError(
+                    f"The observation '{observation}' "
+                    "does not exist in the provided dataset.\n"
+                    "Existing observations are:\n"
+                    f"{existing_obs_str}"
+                )
 
     # Check for specified features existence
     if features is not None:
@@ -150,7 +165,13 @@ def anndata_checks(
         elif not isinstance(features, list):
             raise ValueError("The 'features' parameter should be a \
                              string or a list of strings.")
+        var_name_list = adata.var_names.to_list()
         for feature in features:
-            if feature not in adata.var_names:
-                raise ValueError(f"The feature '{feature}' does not exist \
-                                 in the provided dataset.")
+            if feature not in var_name_list:
+                existing_var_str = "\n".join(var_name_list)
+                raise ValueError(
+                    f"The feature '{feature}' "
+                    "does not exist in the provided dataset.\n"
+                    "Existing features are:\n"
+                    f"{existing_var_str}"
+                )

--- a/tests/test_utils/test_anndata_checks.py
+++ b/tests/test_utils/test_anndata_checks.py
@@ -82,6 +82,84 @@ class TestAnndataChecks(unittest.TestCase):
                                          obs=["obs1"],
                                          features=["feature1"]))
 
+    def test_wrong_adata_type(self):
+        with self.assertRaises(TypeError) as context:
+            anndata_checks("not an AnnData object")
+        self.assertEqual(
+            str(context.exception),
+            "Input dataset should be an instance of anndata.AnnData, "
+            "please check the input dataset source."
+        )
+
+    def test_missing_layers(self):
+        with self.assertRaises(ValueError) as context:
+            anndata_checks(self.adata,
+                           layers=["missing_layer1",
+                                   "missing_layer2"])
+        self.assertEqual(
+            "The table 'missing_layer1' "
+            "does not exist in the provided dataset.\n"
+            "Existing tables are:\nlayer1\nlayer2",
+            str(context.exception)
+        )
+
+        with self.assertRaises(ValueError) as context:
+            anndata_checks(self.adata,
+                           layers=["missing_layer2",
+                                   "missing_layer1"])
+        self.assertEqual(
+            "The table 'missing_layer2' "
+            "does not exist in the provided dataset.\n"
+            "Existing tables are:\nlayer1\nlayer2",
+            str(context.exception)
+        )
+
+    def test_missing_observations(self):
+        with self.assertRaises(ValueError) as context:
+            anndata_checks(self.adata,
+                           obs=["missing_obs1",
+                                "missing_obs2"])
+        self.assertEqual(
+            "The observation 'missing_obs1' does not "
+            "exist in the provided dataset.\n"
+            "Existing observations are:\nobs1\nobs2",
+            str(context.exception)
+        )
+
+        with self.assertRaises(ValueError) as context:
+            anndata_checks(self.adata,
+                           obs=["missing_obs2",
+                                "missing_obs1"])
+        self.assertEqual(
+            "The observation 'missing_obs2' does not "
+            "exist in the provided dataset.\n"
+            "Existing observations are:\nobs1\nobs2",
+            str(context.exception)
+        )
+
+    def test_missing_features(self):
+        with self.assertRaises(ValueError) as context:
+            anndata_checks(self.adata,
+                           features=["missing_feature1",
+                                     "missing_feature2"])
+        self.assertEqual(
+            "The feature 'missing_feature1' does not "
+            "exist in the provided dataset.\n"
+            "Existing features are:\nfeature1\nfeature2",
+            str(context.exception)
+        )
+
+        with self.assertRaises(ValueError) as context:
+            anndata_checks(self.adata,
+                           features=["missing_feature2",
+                                     "missing_feature1"])
+        self.assertEqual(
+            "The feature 'missing_feature2' does not "
+            "exist in the provided dataset.\n"
+            "Existing features are:\nfeature1\nfeature2",
+            str(context.exception)
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_utils/test_anndata_checks.py
+++ b/tests/test_utils/test_anndata_checks.py
@@ -1,0 +1,87 @@
+import unittest
+import numpy as np
+import pandas as pd
+import anndata as ad
+from spac.utils import anndata_checks
+
+
+class TestAnndataChecks(unittest.TestCase):
+
+    def setUp(self):
+        # Create a sample AnnData object for testing
+        data = {
+            "feature1": [1, 3],
+            "feature2": [2, 4]
+        }
+        self.adata = ad.AnnData(
+            X=pd.DataFrame(data),
+            layers={"layer1": np.array([[5, 6], [7, 8]]),
+                    "layer2": np.array([[9, 10], [11, 12]])},
+            obs={"obs1": [1, 2],
+                 "obs2": [3, 4]}
+        )
+
+    def test_valid_input(self):
+        # Test with valid input
+        self.assertIsNone(anndata_checks(self.adata))
+        # No errors should be raised
+
+    def test_invalid_adata_type(self):
+        # Test with invalid adata type
+        with self.assertRaises(TypeError):
+            anndata_checks("not_an_anndata_object")
+
+    def test_invalid_layers(self):
+        # Test with invalid layers
+        with self.assertRaises(ValueError):
+            anndata_checks(self.adata, layers="invalid_layer")
+        with self.assertRaises(ValueError):
+            anndata_checks(self.adata, layers=["layer1", "invalid_layer"])
+
+    def test_invalid_obs(self):
+        # Test with invalid obs
+        with self.assertRaises(ValueError):
+            anndata_checks(self.adata, obs="invalid_observation")
+        with self.assertRaises(ValueError):
+            anndata_checks(self.adata, obs=["obs1", "invalid_observation"])
+
+    def test_invalid_features(self):
+        # Test with invalid features
+        with self.assertRaises(ValueError):
+            anndata_checks(self.adata, features="invalid_feature")
+        with self.assertRaises(ValueError):
+            anndata_checks(self.adata,
+                           features=["feature1", "invalid_feature"])
+
+    def test_none_input(self):
+        # Test with None for all optional parameters
+        self.assertIsNone(anndata_checks(self.adata,
+                                         layers=None,
+                                         obs=None,
+                                         features=None))
+
+    def test_valid_list_input(self):
+        # Test with list input for layers, obs, and features
+        self.assertIsNone(anndata_checks(self.adata,
+                                         layers=["layer1"],
+                                         obs=["obs1"],
+                                         features=["feature1"]))
+
+    def test_valid_single_string_input(self):
+        # Test with single string input for layers, obs, and features
+        self.assertIsNone(anndata_checks(self.adata,
+                                         layers="layer1",
+                                         obs="obs1",
+                                         features="feature1"))
+
+    def test_valid_string_and_list_input(self):
+        # Test with mix of single string and
+        # list input for layers, obs, and features
+        self.assertIsNone(anndata_checks(self.adata,
+                                         layers="layer1",
+                                         obs=["obs1"],
+                                         features=["feature1"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The function has two sets of checks:
Internal (dev) facing: check for input types
External (user) facing: check if input exists in the anndata object.