### PR TITLE
feat: z_score_normalization and unittest

### DIFF
--- a/src/spac/transformations.py
+++ b/src/spac/transformations.py
@@ -493,3 +493,45 @@ def normalize_features(
     adata.layers[new_layer_name] = dataframe
 
     return quantiles
+
+
+def z_score_normalization(adata, layer=None):
+    """
+    Compute z-scores for the provided AnnData object.
+
+    Parameters
+    ----------
+    adata : anndata.AnnData
+        The AnnData object containing the data to normalize.
+    layer : str, optional
+        The name of the layer in the AnnData object to normalize.
+        If None, the main data matrix .X is used.
+
+    Returns
+    -------
+    adata : anndata.AnnData
+        The AnnData object with a new layer 'z_scores' containing the computed
+        z-scores.
+    """
+
+    # Check if the provided layer exists in the AnnData object
+    if layer:
+        check_table(adata, tables=layer)
+
+        means = np.mean(adata.layers[layer], axis=0)
+        std_devs = np.std(adata.layers[layer], axis=0)
+    else:
+        means = np.mean(adata.X, axis=0)
+        std_devs = np.std(adata.X, axis=0)
+
+    # Avoid division by zero
+    std_devs[std_devs == 0] = 1
+
+    if layer:
+        z_scores = (adata.layers[layer] - means) / std_devs
+        adata.layers['z_scores'] = z_scores
+    else:
+        z_scores = (adata.X - means) / std_devs
+        adata.layers['z_scores'] = z_scores
+
+    return adata

--- a/tests/test_transformations/test_zscore_normalization.py
+++ b/tests/test_transformations/test_zscore_normalization.py
@@ -1,0 +1,43 @@
+import unittest
+import numpy as np
+import pandas as pd
+import anndata
+from spac.transformations import z_score_normalization
+
+
+class TestZScoreNormalization(unittest.TestCase):
+
+    def setUp(self):
+        data_df = pd.DataFrame({
+            'Feature1': [2, 4, 6],
+            'Feature2': [5, 10, 15]
+        })
+        var_df = pd.DataFrame(index=data_df.columns)
+        self.adata = anndata.AnnData(X=data_df.values, var=var_df)
+        self.adata.layers["layer1"] = data_df.values * 2
+
+    def test_z_score_normalization_main_matrix(self):
+        normalized_adata = z_score_normalization(self.adata)
+        expected_z_scores = np.array([
+            [-1.22474487, -1.22474487],
+            [0, 0],
+            [1.22474487, 1.22474487]
+        ])
+        np.testing.assert_array_almost_equal(
+            normalized_adata.layers['z_scores'], expected_z_scores
+        )
+
+    def test_z_score_normalization_layer(self):
+        normalized_adata = z_score_normalization(self.adata, layer="layer1")
+        expected_z_scores = np.array([
+            [-1.22474487, -1.22474487],
+            [0, 0],
+            [1.22474487, 1.22474487]
+        ])
+        np.testing.assert_array_almost_equal(
+            normalized_adata.layers['z_scores'], expected_z_scores
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Hi @georgezakinih Following your guidance, I have refactored the hierarchical_heatmap function by returning zscore layer. But due to the complexity of the code, it’s hard to ensure all the unit tests cover all the modification. So I split and compute the z_score separated from hierarchical_heatmap function for you review here. But I am  still open to keep the parameter z_score in the hierarchical_heatmap function if you think it's better. Thank you very much!
