### PR TITLE
hotfix for regex pattern error

### DIFF
--- a/src/spac/utils.py
+++ b/src/spac/utils.py
@@ -49,11 +49,16 @@ def regex_search_list(
             raise TypeError(error_text)
 
     def regex_search(pattern, str):
-        found = re.search(pattern, str)
-        if found is None:
-            pass
-        else:
-            return found.group(0)
+        try:
+            found = re.search(pattern, str)
+            if found is not None:
+                return found.group(0)
+        except re.error as e:
+            raise ValueError(
+                "Error occurred when searching with regex:\n{}\n"
+                "Please review your regex pattern: {}\nIf using * at the start"
+                ", always have a . before the asterisk.".format(e, pattern)
+            )
 
     all_results = []
 

--- a/tests/test_utils/test_regex_search_list.py
+++ b/tests/test_utils/test_regex_search_list.py
@@ -70,6 +70,19 @@ class RegexSearchListTests(unittest.TestCase):
         result = regex_search_list(regex_pattern, list_to_search)
         self.assertEqual(result, expected_result)
 
+    def test_invalid_search_pattern(self):
+        regex_pattern = "*ABCD$"
+        list_to_search = ["ABCD", "ABCD1", "ABCD2", "ABCD3", "ABCD4"]
+        expected_error_msg = (
+            "Error occurred when searching with regex:\n"
+            "nothing to repeat at position 0\nPlease review "
+            "your regex pattern: *ABCD$\nIf using * at the "
+            "start, always have a . before the asterisk."
+                )
+        with self.assertRaises(ValueError) as context:
+            regex_search_list(regex_pattern, list_to_search)
+        self.assertEqual(str(context.exception), expected_error_msg)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This update is to hotfix error discovered by Scott to provide better error handling when regex pattern has syntax error. 