### PR TITLE
fix(select_values): expanded the original function and added corresponding unit tests

### DIFF
--- a/tests/test_data_utils/test_adata_select_values.py
+++ b/tests/test_data_utils/test_adata_select_values.py
@@ -39,13 +39,13 @@ class TestAdataSelectValues(unittest.TestCase):
         # Expecting all cells to be returned
         self.assertEqual(result.n_obs, 10)
 
-    def test_no_matching_values(self):
+    def test_no_matching_values_raises_error(self):
         """
-        Test selecting cells with no matching values.
+        Test providing values not present in the annotation raises a
+        ValueError.
         """
-        result = adata_select_values(self.adata, 'cell_type', ['Nonexistent'])
-        # Expecting no cells to match
-        self.assertEqual(result.n_obs, 0)
+        with self.assertRaises(ValueError):
+            adata_select_values(self.adata, 'cell_type', ['Nonexistent'])
 
     def test_specific_layer(self):
         """

--- a/tests/test_data_utils/test_adata_select_values.py
+++ b/tests/test_data_utils/test_adata_select_values.py
@@ -1,0 +1,78 @@
+import unittest
+import anndata as ad
+import numpy as np
+from spac.data_utils import adata_select_values
+
+
+class TestAdataSelectValues(unittest.TestCase):
+    def setUp(self):
+        """Set up for testing adata_select_values."""
+        # Create an AnnData object with specific annotations
+        self.adata = ad.AnnData(
+            np.random.rand(10, 2),  # 10 cells, 2 genes
+            obs={
+                'cell_type': [
+                    'T', 'T', 'B', 'B', 'NK', 'T', 'T', 'B', 'B', 'NK'
+                ],
+                'condition': [
+                    'healthy', 'infected', 'healthy', 'infected', 'healthy',
+                    'healthy', 'infected', 'infected', 'healthy', 'infected'
+                ]
+            }
+        )
+        # Add a layer with dummy data for testing layer-specific selection
+        self.adata.layers["dummy_layer"] = np.random.rand(10, 2)
+
+    def test_select_values_by_annotation(self):
+        """
+        Test selecting cells based on a single annotation.
+        """
+        result = adata_select_values(self.adata, 'cell_type', ['T', 'B'])
+        # Expecting 8 cells where cell_type is either 'T' or 'B'
+        self.assertEqual(result.n_obs, 8)
+
+    def test_all_cells_no_values_given(self):
+        """
+        Test that all cells are returned when no specific values are given.
+        """
+        result = adata_select_values(self.adata, 'cell_type')
+        # Expecting all cells to be returned
+        self.assertEqual(result.n_obs, 10)
+
+    def test_no_matching_values(self):
+        """
+        Test selecting cells with no matching values.
+        """
+        result = adata_select_values(self.adata, 'cell_type', ['Nonexistent'])
+        # Expecting no cells to match
+        self.assertEqual(result.n_obs, 0)
+
+    def test_specific_layer(self):
+        """
+        Test selecting cells while specifying a layer.
+        """
+        result = adata_select_values(
+            self.adata, 'condition', ['healthy'], layer="dummy_layer"
+        )
+        # Expecting 5 cells to match 'healthy' condition
+        self.assertEqual(result.n_obs, 5)
+
+    def test_invalid_layer(self):
+        """
+        Test handling of invalid layer specification.
+        """
+        with self.assertRaises(ValueError):
+            adata_select_values(
+                self.adata, 'cell_type', ['T'], layer="nonexistent_layer"
+            )
+
+    def test_invalid_annotation(self):
+        """
+        Test handling of invalid annotation.
+        """
+        with self.assertRaises(ValueError):
+            adata_select_values(self.adata, 'nonexistent_annotation', ['T'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_data_utils/test_dataframe_select_values.py
+++ b/tests/test_data_utils/test_dataframe_select_values.py
@@ -12,41 +12,37 @@ class TestDataFrameSelectValues(unittest.TestCase):
         })
 
     def test_select_values_typical_case(self):
-        """
-        Test that function correctly selects specified values from an
-        annotation.
-        """
+        """Test selecting specified values."""
         result = dataframe_select_values(self.data, 'column1', ['A', 'B'])
         self.assertEqual(len(result), 5)
         # Assert that 'C' is not in the result
         self.assertFalse((result['column1'] == 'C').any())
 
     def test_select_values_all_values(self):
-        """
-        Test that function correctly selects all values
-        when no specific values given.
-        """
+        """Test selecting all values when none are specified."""
         result = dataframe_select_values(self.data, 'column1')
         self.assertEqual(len(result), 6)
 
     def test_no_matching_values(self):
-        """
-        Test the case with no matching values.
-        """
-        result = dataframe_select_values(self.data, 'column1', ['D'])
-        self.assertEqual(len(result), 0)
+        """Test selecting with no matching values."""
+        # This expects a ValueError due to validation failure
+        with self.assertRaises(ValueError):
+            dataframe_select_values(self.data, 'column1', ['D'])
+
+    def test_values_not_in_annotation(self):
+        """Test selecting values not present in the specified column."""
+        # This test ensures that the function raises a ValueError
+        # when provided values do not exist in the annotation.
+        with self.assertRaises(ValueError):
+            dataframe_select_values(self.data, 'column1', ['Z'])
 
     def test_invalid_annotation(self):
-        """
-        Test function handling when an invalid annotation name is provided.
-        """
+        """Test with an invalid column name."""
         with self.assertRaises(ValueError):
             dataframe_select_values(self.data, 'invalid_column', ['A'])
 
     def test_empty_dataframe(self):
-        """
-        Test that function correctly handles an empty dataframe.
-        """
+        """Test handling an empty dataframe."""
         empty_data = pd.DataFrame()
         result = dataframe_select_values(empty_data, 'column1', ['A'])
         self.assertEqual(len(result), 0)

--- a/tests/test_data_utils/test_dataframe_select_values.py
+++ b/tests/test_data_utils/test_dataframe_select_values.py
@@ -1,0 +1,56 @@
+import unittest
+import pandas as pd
+from spac.data_utils import dataframe_select_values
+
+
+class TestDataFrameSelectValues(unittest.TestCase):
+    def setUp(self):
+        """Set up a sample DataFrame for testing."""
+        self.data = pd.DataFrame({
+            'column1': ['A', 'B', 'A', 'B', 'A', 'C'],
+            'column2': [1, 2, 3, 4, 5, 6]
+        })
+
+    def test_select_values_typical_case(self):
+        """
+        Test that function correctly selects specified values from an
+        annotation.
+        """
+        result = dataframe_select_values(self.data, 'column1', ['A', 'B'])
+        self.assertEqual(len(result), 5)
+        # Assert that 'C' is not in the result
+        self.assertFalse((result['column1'] == 'C').any())
+
+    def test_select_values_all_values(self):
+        """
+        Test that function correctly selects all values
+        when no specific values given.
+        """
+        result = dataframe_select_values(self.data, 'column1')
+        self.assertEqual(len(result), 6)
+
+    def test_no_matching_values(self):
+        """
+        Test the case with no matching values.
+        """
+        result = dataframe_select_values(self.data, 'column1', ['D'])
+        self.assertEqual(len(result), 0)
+
+    def test_invalid_annotation(self):
+        """
+        Test function handling when an invalid annotation name is provided.
+        """
+        with self.assertRaises(ValueError):
+            dataframe_select_values(self.data, 'invalid_column', ['A'])
+
+    def test_empty_dataframe(self):
+        """
+        Test that function correctly handles an empty dataframe.
+        """
+        empty_data = pd.DataFrame()
+        result = dataframe_select_values(empty_data, 'column1', ['A'])
+        self.assertEqual(len(result), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_data_utils/test_select_values.py
+++ b/tests/test_data_utils/test_select_values.py
@@ -24,14 +24,14 @@ class TestSelectValues(unittest.TestCase):
         """
         Test error raised for a nonexistent annotation in a DataFrame.
         """
-        with self.assertRaises(KeyError):
+        with self.assertRaises(ValueError):
             select_values(self.df, 'nonexistent_column', ['A', 'B'])
 
     def test_adata_nonexistent_annotation(self):
         """
         Test error raised for a nonexistent annotation in an AnnData object.
         """
-        with self.assertRaises(KeyError):
+        with self.assertRaises(ValueError):
             select_values(self.adata, 'nonexistent_column', ['X', 'Y'])
 
     def test_select_values_dataframe_typical_case(self):
@@ -41,13 +41,11 @@ class TestSelectValues(unittest.TestCase):
         result_df = select_values(self.df, 'column1', ['A', 'B'])
         # Expecting 5 rows where column1 is either 'A' or 'B'
         self.assertEqual(len(result_df), 5)
-        # Check that the 'column1' only contains the values 'A' and 'B'
-        unique_values_in_result = result_df['column1'].unique().tolist()
-        self.assertTrue(set(unique_values_in_result).issubset(set(['A', 'B'])))
-        # Alternatively, assert directly the expected values are in the result
+        # Assert that the sets of unique values in the result and expected
+        # values are identical.
         expected_values = ['A', 'B']
-        for value in unique_values_in_result:
-            self.assertIn(value, expected_values)
+        unique_values_in_result = result_df['column1'].unique().tolist()
+        self.assertCountEqual(unique_values_in_result, expected_values)
 
     def test_select_values_adata_typical_case(self):
         """
@@ -57,7 +55,8 @@ class TestSelectValues(unittest.TestCase):
         # Expecting 5 rows where column1 is either 'X' or 'Y'
         self.assertEqual(result_adata.n_obs, 5)
         unique_values_in_result = result_adata.obs['column1'].unique().tolist()
-        self.assertTrue(set(unique_values_in_result).issubset({'X', 'Y'}))
+        expected_values = ['X', 'Y']
+        self.assertCountEqual(unique_values_in_result, expected_values)
 
     def test_select_values_dataframe_all_values(self):
         """
@@ -66,9 +65,9 @@ class TestSelectValues(unittest.TestCase):
         result_df = select_values(self.df, 'column1')
         # Expecting all rows to be returned
         self.assertEqual(len(result_df), 6)
-        self.assertTrue(
-            set(result_df['column1'].unique()).issubset({'A', 'B', 'C'})
-        )
+        unique_values_in_result = result_df['column1'].unique().tolist()
+        expected_values = ['A', 'B', 'C']
+        self.assertCountEqual(unique_values_in_result, expected_values)
 
     def test_select_values_adata_all_values(self):
         """
@@ -77,9 +76,9 @@ class TestSelectValues(unittest.TestCase):
         result_adata = select_values(self.adata, 'column1')
         # Expecting all values to be returned
         self.assertEqual(result_adata.n_obs, 6)
-        self.assertTrue(
-            set(result_adata.obs['column1'].unique()).issubset({'X', 'Y', 'Z'})
-        )
+        unique_values_in_result = result_adata.obs['column1'].unique().tolist()
+        expected_values = ['X', 'Y', 'Z']
+        self.assertCountEqual(unique_values_in_result, expected_values)
 
     def test_unsupported_data_type(self):
         """

--- a/tests/test_data_utils/test_select_values.py
+++ b/tests/test_data_utils/test_select_values.py
@@ -20,6 +20,20 @@ class TestSelectValues(unittest.TestCase):
             obs={'column1': ['X', 'Y', 'X', 'Y', 'X', 'Z']}
         )
 
+    def test_dataframe_nonexistent_annotation(self):
+        """
+        Test error raised for a nonexistent annotation in a DataFrame.
+        """
+        with self.assertRaises(KeyError):
+            select_values(self.df, 'nonexistent_column', ['A', 'B'])
+
+    def test_adata_nonexistent_annotation(self):
+        """
+        Test error raised for a nonexistent annotation in an AnnData object.
+        """
+        with self.assertRaises(KeyError):
+            select_values(self.adata, 'nonexistent_column', ['X', 'Y'])
+
     def test_select_values_dataframe_typical_case(self):
         """
         Test selecting specified values from a DataFrame column.
@@ -27,14 +41,23 @@ class TestSelectValues(unittest.TestCase):
         result_df = select_values(self.df, 'column1', ['A', 'B'])
         # Expecting 5 rows where column1 is either 'A' or 'B'
         self.assertEqual(len(result_df), 5)
+        # Check that the 'column1' only contains the values 'A' and 'B'
+        unique_values_in_result = result_df['column1'].unique().tolist()
+        self.assertTrue(set(unique_values_in_result).issubset(set(['A', 'B'])))
+        # Alternatively, assert directly the expected values are in the result
+        expected_values = ['A', 'B']
+        for value in unique_values_in_result:
+            self.assertIn(value, expected_values)
 
     def test_select_values_adata_typical_case(self):
         """
         Test selecting specified values from an AnnData object.
         """
         result_adata = select_values(self.adata, 'column1', ['X', 'Y'])
-        # Expecting 5 observations where column1 is either 'X' or 'Y'
+        # Expecting 5 rows where column1 is either 'X' or 'Y'
         self.assertEqual(result_adata.n_obs, 5)
+        unique_values_in_result = result_adata.obs['column1'].unique().tolist()
+        self.assertTrue(set(unique_values_in_result).issubset({'X', 'Y'}))
 
     def test_select_values_dataframe_all_values(self):
         """
@@ -43,6 +66,9 @@ class TestSelectValues(unittest.TestCase):
         result_df = select_values(self.df, 'column1')
         # Expecting all rows to be returned
         self.assertEqual(len(result_df), 6)
+        self.assertTrue(
+            set(result_df['column1'].unique()).issubset({'A', 'B', 'C'})
+        )
 
     def test_select_values_adata_all_values(self):
         """
@@ -51,6 +77,9 @@ class TestSelectValues(unittest.TestCase):
         result_adata = select_values(self.adata, 'column1')
         # Expecting all values to be returned
         self.assertEqual(result_adata.n_obs, 6)
+        self.assertTrue(
+            set(result_adata.obs['column1'].unique()).issubset({'X', 'Y', 'Z'})
+        )
 
     def test_unsupported_data_type(self):
         """

--- a/tests/test_data_utils/test_select_values.py
+++ b/tests/test_data_utils/test_select_values.py
@@ -59,6 +59,20 @@ class TestSelectValues(unittest.TestCase):
         with self.assertRaises(TypeError):
             select_values(["not", "a", "valid", "input"], 'column1', ['A'])
 
+    def test_select_values_dataframe_nonexistent_values(self):
+        """
+        Test error raised for nonexistent values from a DataFrame.
+        """
+        with self.assertRaises(ValueError):
+            select_values(self.df, 'column1', ['Nonexistent'])
+
+    def test_select_values_adata_nonexistent_values(self):
+        """
+        Test error raised for nonexistent values from an AnnData object.
+        """
+        with self.assertRaises(ValueError):
+            select_values(self.adata, 'column1', ['Nonexistent'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_data_utils/test_select_values.py
+++ b/tests/test_data_utils/test_select_values.py
@@ -1,57 +1,64 @@
-import os
-import sys
 import unittest
 import pandas as pd
-
-sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "/../../src")
+import anndata as ad
+import numpy as np
 from spac.data_utils import select_values
 
 
 class TestSelectValues(unittest.TestCase):
     def setUp(self):
-        """Set up a sample DataFrame for testing."""
-        self.data = pd.DataFrame({
+        """Set up for testing select_values with both DataFrame and AnnData."""
+        # DataFrame setup with values 'A', 'B', 'C'
+        self.df = pd.DataFrame({
             'column1': ['A', 'B', 'A', 'B', 'A', 'C'],
             'column2': [1, 2, 3, 4, 5, 6]
         })
 
-    def test_select_values_typical_case(self):
-        """
-        Test that function correctly selects specified values from a column.
-        """
-        result = select_values(self.data, 'column1', ['A', 'B'])
-        self.assertEqual(len(result), 5)
-        # Assert that 'C' is not in the result
-        self.assertFalse((result['column1'] == 'C').any())
+        # AnnData setup with values 'X', 'Y', 'Z' for the same 'column1'
+        self.adata = ad.AnnData(
+            np.random.rand(6, 2),
+            obs={'column1': ['X', 'Y', 'X', 'Y', 'X', 'Z']}
+        )
 
-    def test_select_values_all_values(self):
+    def test_select_values_dataframe_typical_case(self):
         """
-        Test that function correctly selects all values
-        when no specific values given.
+        Test selecting specified values from a DataFrame column.
         """
-        result = select_values(self.data, 'column1')
-        self.assertEqual(len(result), 6)
+        result_df = select_values(self.df, 'column1', ['A', 'B'])
+        # Expecting 5 rows where column1 is either 'A' or 'B'
+        self.assertEqual(len(result_df), 5)
 
-    def test_select_values_no_matching_values_with_warning(self):
+    def test_select_values_adata_typical_case(self):
         """
-        Test function handling of case where no values in the
-        column match the specified values and a warning is issued.
+        Test selecting specified values from an AnnData object.
         """
-        with self.assertWarns(UserWarning):
-            result = select_values(self.data, 'column1', ['D'])
-        self.assertEqual(len(result), 0)
+        result_adata = select_values(self.adata, 'column1', ['X', 'Y'])
+        # Expecting 5 observations where column1 is either 'X' or 'Y'
+        self.assertEqual(result_adata.n_obs, 5)
 
-    def test_select_values_invalid_column(self):
-        """Test function handling when an invalid column name is provided."""
-        with self.assertRaises(ValueError):
-            select_values(self.data, 'invalid_column', ['A'])
+    def test_select_values_dataframe_all_values(self):
+        """
+        Test returning all DataFrame rows when no specific values are given.
+        """
+        result_df = select_values(self.df, 'column1')
+        # Expecting all rows to be returned
+        self.assertEqual(len(result_df), 6)
 
-    def test_select_values_empty_dataframe(self):
-        """Test that function correctly handles an empty dataframe."""
-        empty_data = pd.DataFrame()
-        result = select_values(empty_data, 'column1', ['A'])
-        self.assertEqual(len(result), 0)
+    def test_select_values_adata_all_values(self):
+        """
+        Test returning all AnnData values when no specific values are given.
+        """
+        result_adata = select_values(self.adata, 'column1')
+        # Expecting all values to be returned
+        self.assertEqual(result_adata.n_obs, 6)
+
+    def test_unsupported_data_type(self):
+        """
+        Test handling of unsupported data types.
+        """
+        with self.assertRaises(TypeError):
+            select_values(["not", "a", "valid", "input"], 'column1', ['A'])
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This refactoring splits the original functionality of select_values into three distinct functions:

select_values(data, annotation, values=None) is the landing function. 
data can be either dataframe or anndata. 
Based on the data type, it delegates the operation to one of the two specialized functions: 
dataframe_select_values for a DataFrame or adata_select_values for an AnnData object.

Accordingly, three unit tests were added.
