### PR TITLE
fix(get_cluster_info): modified the function and corresponding unit test

### DIFF
--- a/src/spac/transformations.py
+++ b/src/spac/transformations.py
@@ -8,7 +8,7 @@ import scanpy.external as sce
 from spac.utils import check_table, check_annotation, check_feature
 from scipy import stats
 import umap as umap_lib
-from scipy.sparse import issparse
+from scipy.sparse import issparse, isspmatrix
 
 
 def phenograph_clustering(adata, features, layer=None,
@@ -99,33 +99,39 @@ def get_cluster_info(adata, annotation="phenograph", features=None):
     cluster_counts = adata.obs[annotation].value_counts().reset_index()
     cluster_counts.columns = ["Cluster", "Number of Cells"]
 
+    # Calculate the percentage of cells in each cluster
+    total_cells = adata.obs.shape[0]
+    cluster_counts['Percentage'] = (
+        cluster_counts['Number of Cells'] / total_cells
+    ) * 100
+
     # Initialize DataFrame for cluster metrics
     cluster_metrics = pd.DataFrame({"Cluster": cluster_counts["Cluster"]})
 
     # Convert adata.X to DataFrame
-    adata_df = pd.DataFrame(adata.X, columns=adata.var_names)
+    adata_array = adata.X.toarray() if isspmatrix(adata.X) else adata.X
+    adata_df = pd.DataFrame(adata_array, columns=adata.var_names)
 
     # Add cluster annotation
     adata_df[annotation] = adata.obs[annotation].values
 
     # Calculate statistics for each feature in each cluster
     for feature in features:
-        grouped = adata_df.groupby(annotation)[feature].agg(
-            ["mean", "std", "median",
-             lambda x: x.quantile(0),
-             lambda x: x.quantile(0.995)
-             ]).reset_index()
+        grouped = adata_df.groupby(annotation)[feature]\
+                            .agg(["mean", "median"])\
+                            .reset_index()
         grouped.columns = [
             f"{col}_{feature}" if col != annotation else "Cluster"
             for col in grouped.columns
         ]
         cluster_metrics = cluster_metrics.merge(
             grouped, on="Cluster", how="left"
-            )
+        )
 
-    # Merge cluster counts
+    # Merge cluster counts and percentage
     cluster_metrics = pd.merge(
-        cluster_metrics, cluster_counts, on="Cluster", how="left"
+        cluster_metrics, cluster_counts,
+        on="Cluster", how="left"
     )
 
     return cluster_metrics

--- a/tests/test_transformations/test_get_cluster_info.py
+++ b/tests/test_transformations/test_get_cluster_info.py
@@ -19,23 +19,29 @@ class TestGetClusterInfo(unittest.TestCase):
         obs_df = pd.DataFrame(obs_data)
         self.adata = AnnData(X=X_data, obs=obs_df, var=var_data)
 
-    def test_default_features(self):
+    def test_default_features_with_percentage(self):
         result = get_cluster_info(self.adata)
         self.assertIsInstance(result, pd.DataFrame)
         self.assertIn("Cluster", result.columns)
         self.assertIn("Number of Cells", result.columns)
+        self.assertIn("Percentage", result.columns)
         self.assertIn("mean_Gene1", result.columns)
+        # Check that the sum of all percentages is approximately 100
+        self.assertAlmostEqual(
+            result["Percentage"].sum(), 100, places=1
+        )
 
-    def test_specific_features(self):
+    def test_specific_features_with_percentage(self):
         result = get_cluster_info(self.adata, features=["Gene1", "Gene2"])
         self.assertIsInstance(result, pd.DataFrame)
         self.assertIn("Cluster", result.columns)
         self.assertIn("Number of Cells", result.columns)
+        self.assertIn("Percentage", result.columns)
         self.assertIn("mean_Gene1", result.columns)
         self.assertIn("mean_Gene2", result.columns)
         self.assertNotIn("mean_Gene3", result.columns)
 
-    def test_default_features_with_known_values(self):
+    def test_default_features_with_known_values_and_percentage(self):
         # Create a mock AnnData object with specific known values
         X_data = np.array([
             [1, 2],
@@ -62,11 +68,14 @@ class TestGetClusterInfo(unittest.TestCase):
         )
 
         # Manually calculate expected output
-        # For example, for Cluster1, mean of Gene1 should be (1+2)/2 = 1.5
-        # Make assertions based on the expected output
+        # For Cluster1, percentage should be (2/5)*100 = 40.0
         cluster_filter = result['Cluster'] == 'Cluster1'
-        mean_gene1_value = result.loc[cluster_filter, 'mean_Gene1'].iloc[0]
+        percentage_value = result.loc[cluster_filter, 'Percentage']\
+                                 .iloc[0]
+        self.assertAlmostEqual(percentage_value, 40.0, places=1)
 
+        # For Cluster1, mean of Gene1 should be (1+2)/2 = 1.5
+        mean_gene1_value = result.loc[cluster_filter, 'mean_Gene1'].iloc[0]
         self.assertAlmostEqual(mean_gene1_value, 1.5, places=4)
 
 


### PR DESCRIPTION
@georgezakinih  The revised get_cluster_info function has two specified changes:

1. Remove quantile calculations: omit the lambda expressions used for quantile calculations in the aggregation function, keeping only the mean and median calculations.
2. Add percentage of each cluster: calculate the percentage of cells in each cluster relative to the total number of cells and include this information in the cluster_metrics DataFrame.