### PR TITLE
refactor: batch_normalize and unit test

### DIFF
--- a/src/spac/transformations.py
+++ b/src/spac/transformations.py
@@ -297,17 +297,20 @@ def batch_normalize(adata, annotation, output_layer,
             f"allowed methods = {allowed_methods}"
         )
 
-    batches = adata.obs[annotation].unique().tolist()
+    # Create a copy of the input layer or '.X'
     if input_layer:
         original = pd.DataFrame(adata.layers[input_layer],
-                                index=adata.obs.index)
+                                index=adata.obs.index).copy()
     else:
-        original = pd.DataFrame(adata.X, index=adata.obs.index)
+        original = pd.DataFrame(adata.X, index=adata.obs.index).copy()
 
+    # Logarithmic transformation if required
     if log:
         original = np.log2(1+original)
         logging.info("Data transformed with log2")
 
+    # Initialize the batch annotation values
+    batches = adata.obs[annotation].unique().tolist()
     if method == "median" or method == "Q50":
         all_batch_quantile = original.quantile(q=0.5)
         logging.info("Median for al cells: %s", all_batch_quantile)
@@ -317,7 +320,7 @@ def batch_normalize(adata, annotation, output_layer,
     elif method == "z-score":
         logging.info("Z-score setup is handled in batch processing loop.")
 
-    # Place holder for normalized dataframes per batch
+    # Normalize each batch
     for batch in batches:
         batch_cells = original[adata.obs[annotation] == batch]
         logging.info(f"Processing batch: {batch}, "

--- a/tests/test_transformations/test_batch_normalize.py
+++ b/tests/test_transformations/test_batch_normalize.py
@@ -376,6 +376,43 @@ class TestAnalysisMethods(unittest.TestCase):
             ).to_numpy()
         self.assertEqual(np.allclose(ground_truth, normalized_array), True)
 
+    def test_original_data_preserved(self):
+        batch = "region"
+
+        # Original marker data
+        df1 = pd.DataFrame({
+            'marker1': [1, 2, 3],
+            'marker2': [4, 5, 6],
+            batch: "reg1"
+        })
+
+        df2 = pd.DataFrame({
+            'marker1': [7, 8, 9],
+            'marker2': [10, 11, 12],
+            batch: "reg2"
+        })
+
+        # Ingesting the data and concatenating regions
+        adata1 = ingest_cells(df1, "^marker.*", annotation=batch)
+        adata2 = ingest_cells(df2, "^marker.*", annotation=batch)
+
+        all_adata = concatinate_regions([adata1, adata2])
+
+        # Copy the original data to compare later
+        original_data = all_adata.X.copy()
+
+        # Perform batch normalization
+        normalized_layer = "median_normalization"
+        batch_normalize(
+            all_adata,
+            annotation=batch,
+            output_layer=normalized_layer,
+            method="median"
+        )
+
+        # Check that the original data remains intact
+        self.assertTrue(np.array_equal(original_data, all_adata.X))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Including .copy() ensures that the original data remains intact while performing normalization.