### PR TITLE
fix:histogram and corresponding unit tests

### DIFF
--- a/src/spac/visualization.py
+++ b/src/spac/visualization.py
@@ -13,6 +13,7 @@ from spac.utils import check_table, check_annotation
 from spac.utils import check_feature, annotation_category_relations
 from spac.utils import color_mapping
 import logging
+import warnings
 
 # Configure logging
 logging.basicConfig(level=logging.INFO,
@@ -370,6 +371,17 @@ def histogram(adata, feature=None, annotation=None, layer=None,
 
     """
 
+    # If no feature or annotation is specified, apply default behavior
+    if feature is None and annotation is None:
+        # Default to the first feature in adata.var_names
+        feature = adata.var_names[0]
+        warnings.warn(
+            "No feature or annotation specified. "
+            "Defaulting to the first feature: "
+            f"'{feature}'.",
+            UserWarning
+        )
+
     # Use utility functions for input validation
     if layer:
         check_table(adata, tables=layer)
@@ -424,6 +436,11 @@ def histogram(adata, feature=None, annotation=None, layer=None,
             fig, ax_array = plt.subplots(
                 n_groups, 1, figsize=(5, 5 * n_groups)
             )
+
+            # convert a single Axes object to a list
+            if n_groups == 1:
+                ax_array = [ax_array]
+
             for i, ax_i in enumerate(ax_array):
                 sns.histplot(data=df[df[group_by] == groups[i]].dropna(),
                              x=data_column, ax=ax_i, **kwargs)

--- a/tests/test_visualization/test_histogram.py
+++ b/tests/test_visualization/test_histogram.py
@@ -93,6 +93,39 @@ class TestHistogram(unittest.TestCase):
         unique_annotations = self.adata.obs['annotation2'].nunique()
         self.assertEqual(len(axs), unique_annotations)
 
+    def test_histogram_feature_group_by_one_label_annotation(self):
+
+        # Setup an annotation with one value
+        n_cells, n_genes = 100, 3
+        # Create a data matrix with fixed values: [1, 2, 3], [2, 3, 4], ...
+        X = np.array([[(j+1) + i for j in range(n_genes)]
+                      for i in range(n_cells)])
+
+        cell_range = [f'cell_{i}' for i in range(1, n_cells+1)]
+
+        # Create annotations with one label 'A'
+        annotation = pd.DataFrame({
+            'annotation1': ['A' for i in range(n_cells)],
+        }, index=cell_range)
+
+        var = pd.DataFrame(index=['marker1', 'marker2', 'marker3'])
+
+        adata = anndata.AnnData(
+            X.astype(np.float32), obs=annotation, var=var
+        )
+
+        fig, axs = histogram(
+            adata,
+            feature='marker1',
+            group_by='annotation1',
+            together=False
+        )
+        self.assertEqual(len(axs), 1)
+
+        # Check the number of axes returned
+        unique_annotations = adata.obs['annotation1'].nunique()
+        self.assertEqual(len(axs), unique_annotations)
+
     def test_log_scale(self):
         fig, ax = histogram(self.adata, feature='marker1', log_scale=True)
         self.assertTrue(ax[0].get_xscale() == 'log')
@@ -165,6 +198,21 @@ class TestHistogram(unittest.TestCase):
 
         # Check the number of axes returned
         self.assertEqual(len(returned_ax), 1)
+
+    def test_default_first_feature(self):
+        with self.assertWarns(UserWarning) as warning:
+            bin_edges = np.linspace(0.5, 100.5, 101)
+            fig, ax = histogram(self.adata, bins=bin_edges)
+
+        warning_message = ("No feature or annotation specified. "
+                           "Defaulting to the first feature: 'marker1'.")
+        self.assertEqual(str(warning.warning), warning_message)
+
+        self.assertEqual(len(ax), 1)
+
+        # Check the number of bars matches the number of cells
+        bars = ax[0].patches
+        self.assertEqual(len(bars), 100)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
1. modified test_histogram_feature_group_by_one_label_annotation
2. If no feature or annotation is specified, apply default to the first feature in adata.var_names
3. add a unit test to verify the behavior when no feature or annotation is provided, ensuring that the first feature is selected by default and a warning is raised.