### PR TITLE
fix(arcsinh_transformation): add error message and unit tests

### DIFF
--- a/src/spac/transformations.py
+++ b/src/spac/transformations.py
@@ -821,7 +821,9 @@ def arcsinh_transformation(
     """
     # Validate input parameters
     if co_factor is None and percentile is None:
-        raise ValueError("Either co_factor or percentile must be provided.")
+        raise ValueError(
+            "Both co_factor and percentile are None. Provide one to proceed."
+        )
 
     if co_factor is not None and percentile is not None:
         raise ValueError(
@@ -849,6 +851,11 @@ def arcsinh_transformation(
         if annotation is None:
             raise ValueError(
                 "annotation must be provided if per_batch is True."
+            )
+        if annotation not in adata.obs.columns:
+            raise ValueError(
+                f"The annotation '{annotation}' does not exist in the "
+                "AnnData object."
             )
         transformed_data = apply_per_batch(
             data_to_transform, adata.obs[annotation].values,

--- a/tests/test_transformations/test_arcsinh_transformation.py
+++ b/tests/test_transformations/test_arcsinh_transformation.py
@@ -1,6 +1,3 @@
-import os
-import sys
-sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "/../../src")
 import unittest
 import numpy as np
 import pandas as pd
@@ -207,8 +204,8 @@ class TestArcsinhTransformation(unittest.TestCase):
         with self.assertRaises(ValueError) as context:
             arcsinh_transformation(self.adata)
         self.assertEqual(
-            str(context.exception), "Either co_factor or percentile "
-            "must be provided."
+            str(context.exception),
+            "Both co_factor and percentile are None. Provide one to proceed."
         )
 
     def test_arcsinh_transformation_per_batch(self):
@@ -248,6 +245,18 @@ class TestArcsinhTransformation(unittest.TestCase):
         # print("Expected (per batch):", expected_data)
         np.testing.assert_array_almost_equal(
             transformed_adata.layers['arcsinh'], expected_data, decimal=5
+        )
+
+    def test_non_existing_annotation(self):
+        with self.assertRaises(ValueError) as context:
+            arcsinh_transformation(
+                self.adata, per_batch=True,
+                annotation='non_existing', percentile=20
+            )
+        self.assertEqual(
+            str(context.exception),
+            "The annotation 'non_existing' does not exist in the "
+            "AnnData object."
         )
 
 


### PR DESCRIPTION
addressed the issue of handling a non-existing annotation and providing a more informative error message;
Added a specific ValueError when both co_factor and percentile are None with a detailed error message.