### PR TITLE
fix(arcsinh_transformation): change error message and unit tests

### DIFF
--- a/src/spac/transformations.py
+++ b/src/spac/transformations.py
@@ -831,10 +831,14 @@ def arcsinh_transformation(
         )
 
     if co_factor and co_factor <= 0:
-        raise ValueError("Co_factor should be a positive value.")
+        raise ValueError(
+            f'Co_factor should be a positive value. Received: "{co_factor}"'
+        )
 
     if percentile is not None and not (0 <= percentile <= 100):
-        raise ValueError("Percentile should be between 0 and 100.")
+        raise ValueError(
+            f'Percentile should be between 0 and 100. Received: "{percentile}"'
+        )
 
     # Check if the provided input_layer exists in the AnnData object
     if input_layer:
@@ -852,11 +856,9 @@ def arcsinh_transformation(
             raise ValueError(
                 "annotation must be provided if per_batch is True."
             )
-        if annotation not in adata.obs.columns:
-            raise ValueError(
-                f"The annotation '{annotation}' does not exist in the "
-                "AnnData object."
-            )
+        check_annotation(
+            adata, annotations=annotation,parameter_name="annotation"
+        )
         transformed_data = apply_per_batch(
             data_to_transform, adata.obs[annotation].values,
             method='arcsinh_transformation', co_factor=co_factor,

--- a/tests/test_transformations/test_arcsinh_transformation.py
+++ b/tests/test_transformations/test_arcsinh_transformation.py
@@ -162,13 +162,15 @@ class TestArcsinhTransformation(unittest.TestCase):
         with self.assertRaises(ValueError) as context:
             arcsinh_transformation(self.adata, percentile=-0.1)
         self.assertEqual(
-            str(context.exception), "Percentile should be between 0 and 100."
+            str(context.exception),
+            'Percentile should be between 0 and 100. Received: "-0.1"'
         )
 
         with self.assertRaises(ValueError) as context:
             arcsinh_transformation(self.adata, percentile=100.1)
         self.assertEqual(
-            str(context.exception), "Percentile should be between 0 and 100."
+            str(context.exception),
+            'Percentile should be between 0 and 100. Received: "100.1"'
         )
 
     def test_warning_on_overwriting_layer(self):
@@ -245,18 +247,6 @@ class TestArcsinhTransformation(unittest.TestCase):
         # print("Expected (per batch):", expected_data)
         np.testing.assert_array_almost_equal(
             transformed_adata.layers['arcsinh'], expected_data, decimal=5
-        )
-
-    def test_non_existing_annotation(self):
-        with self.assertRaises(ValueError) as context:
-            arcsinh_transformation(
-                self.adata, per_batch=True,
-                annotation='non_existing', percentile=20
-            )
-        self.assertEqual(
-            str(context.exception),
-            "The annotation 'non_existing' does not exist in the "
-            "AnnData object."
         )
 
 


### PR DESCRIPTION
Hi @georgezakinih this commit has used the "Check annotation" utility function, and printed received "negative value" in the error message. Thank you for reviewing.