### PR TITLE
fix(boxplot): set a single tick and label explicitly for single featu…

### DIFF
--- a/src/spac/visualization.py
+++ b/src/spac/visualization.py
@@ -1215,8 +1215,12 @@ def boxplot(adata, annotation=None, second_annotation=None, layer=None,
         else:
             if v_orient:
                 sns.boxplot(y=df[features[0]], ax=ax, **kwargs)
+                ax.set_xticks([0])  # Set a single tick for the single feature
+                ax.set_xticklabels([features[0]])  # Set the label for the tick
             else:
                 sns.boxplot(x=df[features[0]], ax=ax, **kwargs)
+                ax.set_yticks([0])  # Set a single tick for the single feature
+                ax.set_yticklabels([features[0]])  # Set the label for the tick
             ax.set_title("Single Boxplot")
 
     if log_scale:

--- a/tests/test_visualization/test_boxplot.py
+++ b/tests/test_visualization/test_boxplot.py
@@ -250,6 +250,16 @@ class TestBoxplot(unittest.TestCase):
         self.assertEqual(ax.get_xlabel(), 'log(Intensity)')
         self.assertEqual(ax.get_ylabel(), 'phenotype')
 
+    def test_single_feature_labeling(self):
+        """Test if single feature name is displayed correctly on the x-axis."""
+        fig, ax, df = boxplot(self.adata, features=['feature1'], orient='v')
+        xtick_labels = [tick.get_text() for tick in ax.get_xticklabels()]
+        self.assertEqual(xtick_labels, ['feature1'])
+
+        fig, ax, df = boxplot(self.adata, features=['feature1'], orient='h')
+        ytick_labels = [tick.get_text() for tick in ax.get_yticklabels()]
+        self.assertEqual(ytick_labels, ['feature1'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
…res and unit test

By default, seaborn doesn't add axis labels for single features in the same way it does when there are multiple boxplots. In this commit, we set a single tick and label explicitly for single features.