### PR TITLE
fix: axis and plot titles and unit tests

### DIFF
--- a/tests/test_visualization/test_dimensionality_reduction_plot.py
+++ b/tests/test_visualization/test_dimensionality_reduction_plot.py
@@ -60,6 +60,9 @@ class TestDimensionalityReductionPlot(unittest.TestCase):
         )
         self.assertIsNotNone(fig)
         self.assertIsNotNone(ax)
+        self.assertEqual(ax.get_xlabel(), 't-SNE 1')
+        self.assertEqual(ax.get_ylabel(), 't-SNE 2')
+        self.assertEqual(ax.get_title(), 'TSNE')
 
     def test_associated_table(self):
         fig, ax = dimensionality_reduction_plot(
@@ -69,6 +72,9 @@ class TestDimensionalityReductionPlot(unittest.TestCase):
         )
         self.assertIsNotNone(fig)
         self.assertIsNotNone(ax)
+        self.assertEqual(ax.get_xlabel(), 'UMAP 1')
+        self.assertEqual(ax.get_ylabel(), 'UMAP 2')
+        self.assertEqual(ax.get_title(), 'sumap')
 
     def test_feature_column(self):
         fig, ax = dimensionality_reduction_plot(
@@ -76,6 +82,9 @@ class TestDimensionalityReductionPlot(unittest.TestCase):
         )
         self.assertIsNotNone(fig)
         self.assertIsNotNone(ax)
+        self.assertEqual(ax.get_xlabel(), 't-SNE 1')
+        self.assertEqual(ax.get_ylabel(), 't-SNE 2')
+        self.assertEqual(ax.get_title(), 'TSNE')
 
     def test_ax_provided(self):
         fig, ax_provided = plt.subplots()
@@ -91,6 +100,9 @@ class TestDimensionalityReductionPlot(unittest.TestCase):
         )
         self.assertIsInstance(fig, plt.Figure)
         self.assertIsInstance(ax, plt.Axes)
+        self.assertEqual(ax.get_xlabel(), 't-SNE 1')
+        self.assertEqual(ax.get_ylabel(), 't-SNE 2')
+        self.assertEqual(ax.get_title(), 'TSNE')
 
     def test_real_umap_plot(self):
         fig, ax = dimensionality_reduction_plot(
@@ -98,6 +110,9 @@ class TestDimensionalityReductionPlot(unittest.TestCase):
         )
         self.assertIsInstance(fig, plt.Figure)
         self.assertIsInstance(ax, plt.Axes)
+        self.assertEqual(ax.get_xlabel(), 'UMAP 1')
+        self.assertEqual(ax.get_ylabel(), 'UMAP 2')
+        self.assertEqual(ax.get_title(), 'UMAP')
 
     def test_real_pca_plot(self):
         fig, ax = dimensionality_reduction_plot(
@@ -105,6 +120,9 @@ class TestDimensionalityReductionPlot(unittest.TestCase):
         )
         self.assertIsInstance(fig, plt.Figure)
         self.assertIsInstance(ax, plt.Axes)
+        self.assertEqual(ax.get_xlabel(), 'PCA 1')
+        self.assertEqual(ax.get_ylabel(), 'PCA 2')
+        self.assertEqual(ax.get_title(), 'PCA')
 
     def test_invalid_method(self):
         with self.assertRaises(ValueError) as cm:

--- a/tests/test_visualization/test_visualize_2D_scatter.py
+++ b/tests/test_visualization/test_visualize_2D_scatter.py
@@ -95,6 +95,35 @@ class TestVisualize2DScatter(unittest.TestCase):
         aspect = axis.get_aspect()
         self.assertTrue(aspect == 'equal' or aspect == 1.0)
 
+    def test_axis_titles(self):
+        """Test if axis titles are set correctly."""
+        x_axis_title = 'Test X Axis'
+        y_axis_title = 'Test Y Axis'
+        figure, axis = visualize_2D_scatter(
+            self.x, self.y, x_axis_title=x_axis_title,
+            y_axis_title=y_axis_title
+        )
+        self.assertEqual(axis.get_xlabel(), x_axis_title)
+        self.assertEqual(axis.get_ylabel(), y_axis_title)
+
+    def test_plot_title(self):
+        """Test if plot title is set correctly."""
+        plot_title = 'Test Plot Title'
+        figure, axis = visualize_2D_scatter(
+            self.x, self.y, plot_title=plot_title
+        )
+        self.assertEqual(axis.get_title(), plot_title)
+
+    def test_color_representation(self):
+        """Test if color representation description is included in legend."""
+        color_representation = 'Test Color Representation'
+        figure, axis = visualize_2D_scatter(
+            self.x, self.y, labels=self.labels_categorical,
+            color_representation=color_representation
+        )
+        legend = axis.get_legend()
+        self.assertIn(color_representation, legend.get_title().get_text())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR is to refactor visualization functions (visualize_2D_scatter and dimensionality_reduction_plot) by adding parameters for x-axis and y-axis titles, axes names, plot title, and legend. Specifically,
1. Add parameters: add parameters for x-axis title, y-axis title, plot title, and legend label to the visualize_2D_scatter function.
2. Set axis labels and titles: set the x-axis and y-axis labels, plot title, and legend label based on the provided parameters.

4. Specify color representation: ensure the color representation is mentioned in the plot (either in the title or the legend).
In visualize_2D_scatter function, color_representation parameter is used to describe what the colors in the scatter plot represent. When the labels are continuous, it is appended to the plot title. When the labels are categorical, it is used as the legend title.
In dimensionality_reduction_plot function, it is set automatically based on whether annotation or feature is provided.

5. replace logging statement with print statement
