### PR TITLE
fix(dimensionality_reduction_plot): remove the conflicting keys from …

### DIFF
--- a/src/spac/visualization.py
+++ b/src/spac/visualization.py
@@ -309,11 +309,22 @@ def dimensionality_reduction_plot(
         y_axis_title = f'{associated_table} 2'
         plot_title = associated_table
 
+    # Remove conflicting keys from kwargs
+    kwargs.pop('x_axis_title', None)
+    kwargs.pop('y_axis_title', None)
+    kwargs.pop('plot_title', None)
+    kwargs.pop('color_representation', None)
+
     fig, ax = visualize_2D_scatter(
-        x, y, ax=ax, labels=color_values,
+        x=x,
+        y=y,
+        ax=ax,
+        labels=color_values,
+        x_axis_title=x_axis_title,
+        y_axis_title=y_axis_title,
+        plot_title=plot_title,
         color_representation=color_representation,
-        x_axis_title=x_axis_title, y_axis_title=y_axis_title,
-        plot_title=plot_title, **kwargs
+        **kwargs
     )
 
     return fig, ax

--- a/tests/test_visualization/test_dimensionality_reduction_plot.py
+++ b/tests/test_visualization/test_dimensionality_reduction_plot.py
@@ -141,6 +141,23 @@ class TestDimensionalityReductionPlot(unittest.TestCase):
 
         self.assertEqual(str(cm.exception), expected_msg)
 
+    def test_conflicting_kwargs(self):
+        # This test ensures conflicting keys are removed from kwargs
+        fig, ax = dimensionality_reduction_plot(
+            self.adata,
+            'tsne',
+            annotation='annotation_column',
+            x_axis_title='Conflict X',
+            y_axis_title='Conflict Y',
+            plot_title='Conflict Title',
+            color_representation='Conflict Color'
+        )
+        self.assertIsNotNone(fig)
+        self.assertIsNotNone(ax)
+        self.assertEqual(ax.get_xlabel(), 't-SNE 1')
+        self.assertEqual(ax.get_ylabel(), 't-SNE 2')
+        self.assertEqual(ax.get_title(), 'TSNE')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
…kwargs and add unit test

When deployed the dimensionality_reduction_plot function on NIDAP, the error "TypeError: visualize_2D_scatter() got multiple values for keyword argument 'x_axis_title'" indicates a conflict in how the x_axis_title argument is passed to the visualize_2D_scatter function. This conflict usually occurs because **kwargs already contains a value for x_axis_title.

To resolve this, remove the conflicting keys from **kwargs, including x_axis_title, y_axis_title, or any other defined arguments being passed to visualize_2D_scatter. This solution had been confirmed working on NIDAP code workbook.