### PR TITLE
fix(normalize_features_core): adjust argument to match numpy version …

### DIFF
--- a/src/spac/transformations.py
+++ b/src/spac/transformations.py
@@ -756,10 +756,20 @@ def normalize_features_core(data, low_quantile=0.02, high_quantile=0.98,
             "Interpolation must be either 'nearest' or 'linear', "
             f"passed value is: {interpolation}")
 
-    # Calculate the quantiles
-    quantiles = np.quantile(
-        data, [low_quantile, high_quantile], axis=0,
-        method=interpolation)
+    # Version check for numpy
+    numpy_version = np.__version__
+    if numpy_version >= '1.22.0':
+        # Use 'method' argument for newer versions
+        quantiles = np.quantile(
+            data, [low_quantile, high_quantile], axis=0,
+            method=interpolation
+        )
+    else:
+        # Use 'interpolation' argument for older versions
+        quantiles = np.quantile(
+            data, [low_quantile, high_quantile], axis=0,
+            interpolation=interpolation
+        )
 
     qmin = quantiles[0]
     qmax = quantiles[1]
@@ -857,7 +867,7 @@ def arcsinh_transformation(
                 "annotation must be provided if per_batch is True."
             )
         check_annotation(
-            adata, annotations=annotation,parameter_name="annotation"
+            adata, annotations=annotation, parameter_name="annotation"
         )
         transformed_data = apply_per_batch(
             data_to_transform, adata.obs[annotation].values,

--- a/tests/test_transformations/test_normalize_features_core.py
+++ b/tests/test_transformations/test_normalize_features_core.py
@@ -83,7 +83,7 @@ class TestNormalizeFeaturesCore(unittest.TestCase):
             "The low quantile should be smaller than the high quantile, "
             "current values are:\nlow quantile: 0.5\nhigh quantile: 0.5")
 
-    def test_invalid_method(self):
+    def test_invalid_interpolation(self):
         # Test with invalid method
         with self.assertRaises(ValueError) as context:
             normalize_features_core(self.data_normalization, 0.2, 0.8,


### PR DESCRIPTION
…and unit test

The method argument in np.quantile was introduced in numpy version 1.22.0. Since we are using numpy version 1.19.5, this argument is not available, leading to the TypeError.

To solve this issue, I used the interpolation argument, which is available in numpy versions prior to 1.22.0 for compatibility with numpy 1.15.0. The modified code is:

# Version check for numpy
numpy_version = np.__version__
if numpy_version >= '1.22.0':
    # Use 'method' argument for newer versions
    quantiles = np.quantile(
        data, [low_quantile, high_quantile], axis=0,
        method=interpolation  # Use 'method' for numpy >= 1.22.0
    )
else:
    # Use 'interpolation' argument for older versions
    quantiles = np.quantile(
        data, [low_quantile, high_quantile], axis=0,
        interpolation=interpolation  # Use 'interpolation' for numpy < 1.22.0
    )