### PR TITLE
fix(calculate_centroid): add new columns in a single operation

### DIFF
--- a/src/spac/data_utils.py
+++ b/src/spac/data_utils.py
@@ -776,7 +776,8 @@ def calculate_centroid(
     Returns
     -------
     data : pd.DataFrame
-        dataframe with two new centroid columns addded.
+        dataframe with two new centroid columns addded. Note that the
+        dataframe is modified in place.
 
     """
 
@@ -807,6 +808,9 @@ def calculate_centroid(
     data[[new_x, new_y]] = pd.concat(
         [x_centroid, y_centroid], axis=1, keys=[new_x, new_y]
     )
+
+    # Return the modified DataFrame
+    return data
 
 
 def bin2cat(data, one_hot_annotations, new_annotation):

--- a/src/spac/data_utils.py
+++ b/src/spac/data_utils.py
@@ -767,7 +767,7 @@ def calculate_centroid(
     y_max : str
         column name with maximum y value
     new_x : str
-        the new column name of the x dimension of the centroid,
+        the new column name of the x dimension of the cientroid,
         allowing characters are alphabetic, digits and underscore
     new_y : str
         the new column name of the y dimension of the centroid,
@@ -776,7 +776,7 @@ def calculate_centroid(
     Returns
     -------
     data : pd.DataFrame
-        dataframe with two new columns names
+        dataframe with two new centroid columns addded.
 
     """
 
@@ -799,11 +799,14 @@ def calculate_centroid(
         if col not in data.columns:
             raise ValueError(f"Column {col} does not exist in the dataframe.")
 
-    # calculate the centroids
-    data[new_x] = (data[x_min] + data[x_max]) / 2
-    data[new_y] = (data[y_min] + data[y_max]) / 2
+    # Calculate the centroids
+    x_centroid = (data[x_min] + data[x_max]) / 2
+    y_centroid = (data[y_min] + data[y_max]) / 2
 
-    return data
+    # Assign new centroid columns to the DataFrame in one operation
+    data[[new_x, new_y]] = pd.concat(
+        [x_centroid, y_centroid], axis=1, keys=[new_x, new_y]
+    )
 
 
 def bin2cat(data, one_hot_annotations, new_annotation):


### PR DESCRIPTION
Problem: Adding columns one at a time to a large DataFrame causes fragmentation and performance issues. The warning suggests using pd.concat(axis=1) to add all new columns at once. 

Solution: Calculate new columns separately.  Use pd.concat(axis=1) to concatenate new columns to the original DataFrame in one operation, avoiding fragmentation. 