### PR TITLE
fix(histogram): return a single Axes and fix corner case of normalize…

### DIFF
--- a/src/spac/transformations.py
+++ b/src/spac/transformations.py
@@ -10,6 +10,7 @@ from scipy import stats
 import umap as umap_lib
 from scipy.sparse import issparse
 from typing import List, Union, Optional
+from numpy.lib import NumpyVersion
 
 
 # Configure logging
@@ -690,7 +691,7 @@ def normalize_features_core(data, low_quantile=0.02, high_quantile=0.98,
     Normalize the features in a numpy array.
 
     Any entry lower than the value corresponding to low_quantile of the column
-    will be assigned a value of low_quantile, and entry that are greater than
+    will be assigned a value of low_quantile, and entries that are greater than
     high_quantile value will be assigned as value of high_quantile.
     Other entries will be normalized with
     (values - quantile min)/(quantile max - quantile min).
@@ -728,7 +729,7 @@ def normalize_features_core(data, low_quantile=0.02, high_quantile=0.98,
         If low_quantile is not less than high_quantile, or if they are
         out of the range [0, 1] and (0, 1], respectively.
     ValueError
-        If method is not one of the allowed values.
+        If interpolation is not one of the allowed values.
     """
     if not isinstance(high_quantile, (int, float)):
         raise TypeError(
@@ -761,9 +762,9 @@ def normalize_features_core(data, low_quantile=0.02, high_quantile=0.98,
             "Interpolation must be either 'nearest' or 'linear', "
             f"passed value is: {interpolation}")
 
-    # Version check for numpy
+    # Version check for numpy using NumpyVersion
     numpy_version = np.__version__
-    if numpy_version >= '1.22.0':
+    if NumpyVersion(numpy_version) >= NumpyVersion('1.22.0'):
         # Use 'method' argument for newer versions
         quantiles = np.quantile(
             data, [low_quantile, high_quantile], axis=0,
@@ -779,10 +780,13 @@ def normalize_features_core(data, low_quantile=0.02, high_quantile=0.98,
     qmin = quantiles[0]
     qmax = quantiles[1]
 
-    # Prevent division by zero in case qmax equals qmin
+    # Calculate range_values and identify zero ranges
     range_values = qmax - qmin
+    zero_range_mask = range_values == 0
+
+    # Prevent division by zero by setting zero ranges to 1 temporarily
     range_values = range_values.astype(float)
-    range_values[range_values == 0] = 1
+    range_values[zero_range_mask] = 1.0
 
     # Clip raw values to the quantile range before normalization
     clipped_data = np.clip(data, qmin, qmax)
@@ -790,8 +794,8 @@ def normalize_features_core(data, low_quantile=0.02, high_quantile=0.98,
     # Normalize the clipped values
     normalized_data = (clipped_data - qmin) / range_values
 
-    # Handle columns where qmax equals qmin
-    normalized_data[:, qmax == qmin] = 0
+    # Correct normalized data for zero ranges
+    normalized_data[:, zero_range_mask] = 0.0
 
     return normalized_data
 

--- a/src/spac/visualization.py
+++ b/src/spac/visualization.py
@@ -460,8 +460,9 @@ def histogram(adata, feature=None, annotation=None, layer=None,
     fig : matplotlib.figure.Figure
         The created figure for the plot.
 
-    axs : list[matplotlib.axes.Axes]
-        List of the axes of the histogram plots.
+    axs : matplotlib.axes.Axes or list of Axes
+        The Axes object(s) of the histogram plot(s). Returns a single Axes
+        if only one plot is created, otherwise returns a list of Axes.
 
     """
 
@@ -535,6 +536,8 @@ def histogram(adata, feature=None, annotation=None, layer=None,
             # Ensure ax_array is always iterable
             if n_groups == 1:
                 ax_array = [ax_array]
+            else:
+                ax_array = ax_array.flatten()
 
             for i, ax_i in enumerate(ax_array):
                 sns.histplot(data=df[df[group_by] == groups[i]].dropna(),
@@ -545,7 +548,10 @@ def histogram(adata, feature=None, annotation=None, layer=None,
         sns.histplot(data=df, x=data_column, ax=ax, **kwargs)
         axs.append(ax)
 
-    return fig, axs
+    if len(axs) == 1:
+        return fig, axs[0]
+    else:
+        return fig, axs
 
 
 def heatmap(adata, column, layer=None, **kwargs):

--- a/tests/test_transformations/test_normalize_features_core.py
+++ b/tests/test_transformations/test_normalize_features_core.py
@@ -84,7 +84,7 @@ class TestNormalizeFeaturesCore(unittest.TestCase):
             "current values are:\nlow quantile: 0.5\nhigh quantile: 0.5")
 
     def test_invalid_interpolation(self):
-        # Test with invalid method
+        # Test with invalid interpolation method
         with self.assertRaises(ValueError) as context:
             normalize_features_core(self.data_normalization, 0.2, 0.8,
                                     interpolation='invalid')
@@ -119,8 +119,8 @@ class TestNormalizeFeaturesCore(unittest.TestCase):
 
         # Normalize data based on calculated qmin and qmax
         expected_result = np.array([
-            [0, 0, 0, 1, 1],
-            [1, 1, 0, 0, 0]
+            [0.0, 0.0, 0.0, 1.0, 1.0],
+            [1.0, 1.0, 0.0, 0.0, 0.0]
         ])
         normalized_data = normalize_features_core(
             self.data_normalization, low_quantile, high_quantile, interpolation
@@ -129,8 +129,7 @@ class TestNormalizeFeaturesCore(unittest.TestCase):
                                        decimal=6)
 
     def test_correct_normalization_nearest(self):
-        # Test scaling the features between 0-1 with quantile-based
-        # normalization
+        # Test scaling the features between 0-1 with 'nearest' interpolationn
         low_quantile = 0.2
         high_quantile = 0.8
         interpolation = 'nearest'
@@ -153,8 +152,8 @@ class TestNormalizeFeaturesCore(unittest.TestCase):
         # = (2 - 2) / (4 - 2) = 0
         # Normalize data based on calculated qmin and qmax
         expected_result = np.array([
-            [0, 0, 0, 1, 1],
-            [1, 1, 0, 0, 0]
+            [0.0, 0.0, 0.0, 1.0, 1.0],
+            [1.0, 1.0, 0.0, 0.0, 0.0]
         ])
 
         normalized_data = normalize_features_core(

--- a/tests/test_visualization/test_histogram.py
+++ b/tests/test_visualization/test_histogram.py
@@ -51,7 +51,7 @@ class TestHistogram(unittest.TestCase):
         fig, ax = histogram(self.adata, feature='marker1', bins=bin_edges)
 
         # Check the histogram bars
-        bars = ax[0].patches
+        bars = ax.patches
         # Expecting 100 bars for 100 distinct values
         self.assertEqual(len(bars), 100)
 
@@ -66,18 +66,18 @@ class TestHistogram(unittest.TestCase):
                 bar.get_x() + bar.get_width() / 2, expected_center
             )
 
-        # Check the number of axes returned
-        self.assertEqual(len(ax), 1)
+        # Check that ax is an Axes object
+        self.assertIsInstance(ax, mpl.axes.Axes)
 
     def test_histogram_annotation(self):
         fig, ax = histogram(self.adata, annotation='annotation1')
         total_annotation = len(self.adata.obs['annotation1'])
         # Assuming the y-axis of the histogram represents counts
         # (not frequencies or probabilities)
-        self.assertEqual(sum(p.get_height() for p in ax[0].patches),
+        self.assertEqual(sum(p.get_height() for p in ax.patches),
                          total_annotation)
-        # Check the number of axes returned
-        self.assertEqual(len(ax), 1)
+        # Check that ax is an Axes object
+        self.assertIsInstance(ax, mpl.axes.Axes)
 
     def test_histogram_feature_group_by(self):
         fig, axs = histogram(
@@ -120,7 +120,10 @@ class TestHistogram(unittest.TestCase):
             group_by='annotation1',
             together=False
         )
-        self.assertEqual(len(axs), 1)
+        # Since only one plot is created, axs is an Axes object
+        self.assertIsInstance(axs, mpl.axes.Axes)
+        # Wrap axs in a list for consistent handling
+        axs = [axs]
 
         # Check the number of returned axes matches the unique group count
         unique_annotations = adata.obs['annotation1'].nunique()
@@ -128,7 +131,7 @@ class TestHistogram(unittest.TestCase):
 
     def test_log_scale(self):
         fig, ax = histogram(self.adata, feature='marker1', log_scale=True)
-        self.assertTrue(ax[0].get_xscale() == 'log')
+        self.assertTrue(ax.get_xscale() == 'log')
 
     def test_overlay_options(self):
         fig, ax = histogram(
@@ -140,7 +143,7 @@ class TestHistogram(unittest.TestCase):
             element="step"
         )
         self.assertIsInstance(fig, mpl.figure.Figure)
-        self.assertIsInstance(ax[0], mpl.axes.Axes)
+        self.assertIsInstance(ax, mpl.axes.Axes)
 
     def test_layer(self):
         # Create synthetic data with known values for a subset of the data
@@ -171,7 +174,7 @@ class TestHistogram(unittest.TestCase):
             bins=[0.5, 1.5, 2.5, 3.5])
 
         # Check the histogram bars
-        bars = ax[0].patches
+        bars = ax.patches
         self.assertEqual(len(bars), 3)  # Expecting 3 bars for synthetic data
 
         # Check the height and position of each bar to match the synthetic data
@@ -191,13 +194,13 @@ class TestHistogram(unittest.TestCase):
             ax=ax
         )
         # Check that the passed ax is the one that is returned
-        self.assertEqual(id(returned_ax[0]), id(ax))
+        self.assertEqual(id(returned_ax), id(ax))
 
         # Check that the passed fig is the one that is returned
         self.assertIs(fig, returned_fig)
 
-        # Check the number of axes returned
-        self.assertEqual(len(returned_ax), 1)
+        # Check that returned_ax is an Axes object
+        self.assertIsInstance(returned_ax, mpl.axes.Axes)
 
     def test_default_first_feature(self):
         with self.assertWarns(UserWarning) as warning:
@@ -208,10 +211,11 @@ class TestHistogram(unittest.TestCase):
                            "Defaulting to the first feature: 'marker1'.")
         self.assertEqual(str(warning.warning), warning_message)
 
-        self.assertEqual(len(ax), 1)
+        # Check that ax is an Axes object
+        self.assertIsInstance(ax, mpl.axes.Axes)
 
         # Check the number of bars matches the number of cells
-        bars = ax[0].patches
+        bars = ax.patches
         self.assertEqual(len(bars), 100)
 
 


### PR DESCRIPTION
… features core function and unit tests

In the histogram function, adjust the return statement to return a single Axes object when only one plot is created, accordingly, the unit tests are modified.

In the normalize_features_core function, handle an edge case and correct the comparison of numpy versions.



