### PR TITLE
fix(calculate_nearest_neighbor): reindex to match adata.obs and unit test

### DIFF
--- a/src/spac/spatial_analysis.py
+++ b/src/spac/spatial_analysis.py
@@ -1149,8 +1149,8 @@ def calculate_nearest_neighbor(
 ):
     """
     Computes the shortest distance from each cell to the nearest cell of
-    each phenotype `scimap.tl.spatial_distance`, and stores the resulted
-    DataFrame in `adata.obsm[label]`.
+    each phenotype (via scimap.tl.spatial_distance) and stores the
+    resulting DataFrame in `adata.obsm[label]`.
 
     Parameters
     ----------
@@ -1254,11 +1254,10 @@ def calculate_nearest_neighbor(
     adata.obs['_x_coord'] = coords[:, 0]
     adata.obs['_y_coord'] = coords[:, 1]
 
+    use_z = False
     if coords.shape[1] > 2:
         adata.obs['_z_coord'] = coords[:, 2]
         use_z = True
-    else:
-        use_z = False
 
     # Handle imageid logic
     dummy_column_created = False
@@ -1266,9 +1265,8 @@ def calculate_nearest_neighbor(
     if imageid is None:
         dummy_column_created = True
         imageid = '_dummy_imageid'
-        adata.obs[imageid] = 'dummy_image'  # All cells belong to one 'image'
+        adata.obs[imageid] = 'dummy_image'  # Treat all cells as one 'image'
 
-    # Run scimap's spatial_distance function
     sm.tl.spatial_distance(
         adata=adata,
         x_coordinate='_x_coord',
@@ -1281,9 +1279,13 @@ def calculate_nearest_neighbor(
     )
 
     # The scimap function stores the result in adata.uns[label].
-    # Move it to adata.obsm.
+    # Need to align it to adata.obs_names before placing into .obsm.
     result_df = adata.uns.pop(label)  # remove from uns and capture
-    adata.obsm[label] = result_df  # store in obsm
+
+    # Reindex the results to match adata.obs_names.
+    result_df = result_df.reindex(adata.obs_names)
+
+    adata.obsm[label] = result_df
 
     # Remove temporary coordinates from adata.obs
     drop_cols = ['_x_coord', '_y_coord']
@@ -1294,8 +1296,7 @@ def calculate_nearest_neighbor(
     # Remove dummy column if it was created
     if dummy_column_created:
         adata.obs.drop(columns=[imageid], inplace=True, errors='ignore')
-        # Restore imageid to None to reflect the input
-        imageid = original_imageid
+        imageid = original_imageid  # restore the original state
 
     if verbose:
         print(f"Spatial distances stored in adata.obsm['{label}']")


### PR DESCRIPTION

The refactored version of calculate_nearest_neighbor resolved the index mismatch by reindexing the result DataFrame before storing it in adata.obsm. This ensures the final DataFrame will have exactly the same row labels (and order) as adata.obs_names, which Anndata requires for storing in .obsm.