### PR TITLE
fix(select_values): adata.obsm remain numpy arrays

### DIFF
--- a/src/spac/data_utils.py
+++ b/src/spac/data_utils.py
@@ -525,9 +525,9 @@ def _select_values_anndata(data, annotation, values, exclude_values):
 
     # Proceed with filtering based on values or exclude_values
     if values is not None:
-        filtered_data = data[data.obs[annotation].isin(values)]
+        filtered_data = data[data.obs[annotation].isin(values)].copy()
     elif exclude_values is not None:
-        filtered_data = data[~data.obs[annotation].isin(exclude_values)]
+        filtered_data = data[~data.obs[annotation].isin(exclude_values)].copy()
 
     count = filtered_data.n_obs
     logging.info(

--- a/tests/test_data_utils/test_select_values.py
+++ b/tests/test_data_utils/test_select_values.py
@@ -142,7 +142,9 @@ class TestSelectValues(unittest.TestCase):
         Test error raised for nonexistent values from an AnnData object.
         """
         with self.assertRaises(ValueError):
-            select_values(self.adata, 'column1', exclude_values=['Nonexistent'])
+            select_values(
+                self.adata, 'column1', exclude_values=['Nonexistent']
+            )
 
     def test_both_values_and_exclude_values(self):
         """
@@ -158,6 +160,24 @@ class TestSelectValues(unittest.TestCase):
         # Check that the error is raised with proper message
         error_msg = "Only use with values to include or exclude, but not both."
         self.assertEqual(str(cm.exception), error_msg)
+
+    def test_select_values_adata_obsm_ndarray(self):
+        """
+        Ensure adata.obsm array remains a NumPy array.
+        """
+        adata_with_spatial = ad.AnnData(
+            np.random.rand(6, 3),
+            obs={'column1': ['X', 'Y', 'X', 'Y', 'X', 'Z']}
+        )
+        adata_with_spatial.obsm['spatial'] = np.random.rand(6, 2)
+
+        result_adata = select_values(
+            adata_with_spatial,
+            'column1',
+            values=['X', 'Y']
+        )
+
+        self.assertIsInstance(result_adata.obsm['spatial'], np.ndarray)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In AnnData, slicing operations like filtered_data = data[data.obs[annotation].isin(values)] will by default create a view rather than a full copy whenever possible. That means that objects such as adata.obsm["spatial"] (which started out as a real NumPy array) can become an ArrayView in the sliced AnnData object.

To have an actual copy (with all arrays as raw NumPy),  calling:
filtered_data = data[data.obs[annotation].isin(values)].copy()
This makes a deep copy of all attributes (including .obsm["spatial"]) and ensures they remain as standard NumPy arrays rather than ArrayViews.