### PR TITLE
perf: updating the default colormap for interactive spatial to rainbow

### DIFF
--- a/src/spac/visualization.py
+++ b/src/spac/visualization.py
@@ -1417,7 +1417,7 @@ def interative_spatial_plot(
     annotations,
     dot_size=1.5,
     dot_transparancy=0.75,
-    colorscale='viridis',
+    colorscale='rainbow',
     figure_width=6,
     figure_height=4,
     figure_dpi=200,

--- a/tests/test_visualization/test_interactive_spatial_plot.py
+++ b/tests/test_visualization/test_interactive_spatial_plot.py
@@ -93,9 +93,9 @@ class TestInteractiveSpatialPlot(unittest.TestCase):
                 ["<b>annotation_1</b>", "c"]
         ]
         expected_colors = {
-            'a': 'rgb(68,1,84)',
-            'b': 'rgb(32,144,140)',
-            'c': 'rgb(253,231,36)'
+            'a': 'rgb(127,0,255)',
+            'b': 'rgb(128,254,179)',
+            'c': 'rgb(255,0,0)'
         }
         for i, itr_fig in enumerate(fig_list):
             


### PR DESCRIPTION
Plotly does not have discrete colormap string for selection, the discrete color assignment is basing on the plotting data
Thus a continuous colormap with many colors in scale should give a good proximation to a discrete color map
More information about the plotly color map is in [Built-in Continuous Color Scales in Python](https://plotly.com/python/builtin-colorscales/).