### PR TITLE
feat: adding automated bin cal to histogram

### DIFF
--- a/src/spac/visualization.py
+++ b/src/spac/visualization.py
@@ -540,6 +540,25 @@ def histogram(adata, feature=None, annotation=None, layer=None,
     # Prepare the data for plotting
     plot_data = df.dropna(subset=[data_column])
 
+    # Bin calculation section
+    # The default bin calculation used by sns.histo take quite
+    # some time to compute for large number of points,
+    # DMAP implemented the Rice rule for bin computation
+
+    def cal_bin_num(
+        num_rows
+    ):
+        bins = max(int(2*(num_rows ** (1/3))), 1)
+        print(f'Automatically calculated number of bins is: {bins}')
+        return(bins)
+
+    num_rows = plot_data.shape[0]
+
+    # Check if bins is being passed
+    # If not, the in house algorithm will compute the number of bins 
+    if 'bins' not in kwargs:
+        kwargs['bins'] = cal_bin_num(num_rows)
+
     # Plotting with or without grouping
     if group_by:
         groups = df[group_by].dropna().unique().tolist()

--- a/tests/test_visualization/test_histogram.py
+++ b/tests/test_visualization/test_histogram.py
@@ -320,6 +320,31 @@ class TestHistogram(unittest.TestCase):
         bars = ax.patches
         self.assertEqual(len(bars), 100)
 
+    def test_histogram_feature_integer_bins(self):
+        custom_bins = 10  # Specify number of bins as an integer
+
+        fig, ax = histogram(self.adata, feature='marker1', bins=custom_bins)
+
+        # Check the number of bins used
+        bars = ax.patches
+        self.assertEqual(len(bars), custom_bins)
+
+        # Check that ax is an Axes object
+        self.assertIsInstance(ax, mpl.axes.Axes)
+
+    def test_default_bins_calculation(self):
+        # No bins parameter passed
+        fig, ax = histogram(self.adata, feature='marker1')
+
+        # Count the number of bins
+        bars = ax.patches
+        n_bins = len(bars)
+
+        # Validate the number of bins based on default bin calculation logic
+        # Using 2 * (n ** 1/3) heuristic for default bins
+        expected_bins = max(int(2 * (self.adata.shape[0] ** (1 / 3))), 1)
+        self.assertEqual(n_bins, expected_bins)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Updating the bin calculation to histogram in SPAC:
1. The automatic bin calculation for histogram in seaborn is slow for large row number and continuous data.
2. The Rice Rule is used for computation.
3. Implementation is through appending a "bins" arg into kwargs to minimize disturb of original function