### PR TITLE
Spatial annos

### DIFF
--- a/src/spac/utils.py
+++ b/src/spac/utils.py
@@ -1007,7 +1007,11 @@ def get_defined_color_map(adata, defined_color_map=None, annotations=None,
                 "an annotation column must be specified."
             )
         # Generate a color mapping based on unique values in the annotation
-        unique_labels = np.unique(adata.obs[annotations].values)
+        if isinstance(annotations, str):
+            annotations = [annotations]
+        combined_labels = np.concatenate([adata.obs[col].astype(str).values for col in annotations])
+        unique_labels = np.unique(combined_labels)
+        
         return color_mapping(
             unique_labels,
             color_map=colorscale,

--- a/src/spac/utils.py
+++ b/src/spac/utils.py
@@ -1009,9 +1009,9 @@ def get_defined_color_map(adata, defined_color_map=None, annotations=None,
         # Generate a color mapping based on unique values in the annotation
         if isinstance(annotations, str):
             annotations = [annotations]
-        combined_labels = np.concatenate([adata.obs[col].astype(str).values for col in annotations])
+        combined_labels = np.concatenate(
+            [adata.obs[col].astype(str).values for col in annotations])
         unique_labels = np.unique(combined_labels)
-        
         return color_mapping(
             unique_labels,
             color_map=colorscale,

--- a/tests/test_utils/test_get_defined_color_map.py
+++ b/tests/test_utils/test_get_defined_color_map.py
@@ -106,11 +106,11 @@ class TestGetDefinedColorMap(unittest.TestCase):
         Test handling of list-based annotations,
         raises a NotImplementedError.
         """
-        with self.assertRaises(NotImplementedError):
-            get_defined_color_map(
-                self.dummy_adata,
-                annotations=['cell_type', 'status'],
-            )
+        obs = {'my_ann': pd.Series(['a', 'b', 'a']), 'my_ann_2': pd.Series(['a', 'b', 'a'])}
+        dummy = DummyAnnData(uns={'dummy': {}}, obs=obs)
+        result = get_defined_color_map(dummy,
+                annotations=list(('my_ann', 'my_ann_2')))
+        self.assertIsNotNone(result)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_utils/test_get_defined_color_map.py
+++ b/tests/test_utils/test_get_defined_color_map.py
@@ -101,6 +101,16 @@ class TestGetDefinedColorMap(unittest.TestCase):
         ):
             get_defined_color_map(dummy, defined_color_map=None)
 
+    def test_generate_color_map_multiple_annotations(self):
+        """
+        Test handling of list-based annotations,
+        raises a NotImplementedError.
+        """
+        with self.assertRaises(NotImplementedError):
+            get_defined_color_map(
+                self.dummy_adata,
+                annotations=['cell_type', 'status'],
+            )
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_utils/test_get_defined_color_map.py
+++ b/tests/test_utils/test_get_defined_color_map.py
@@ -86,7 +86,8 @@ class TestGetDefinedColorMap(unittest.TestCase):
         self.assertIn('a', result)
         self.assertIn('b', result)
         # Check that the colors are correctly generated.
-        self.assertTrue(all(isinstance(color, str) for color in result.values()))
+        self.assertTrue(all(isinstance(color, str) for color
+                        in result.values()))
 
     def test_missing_annotations(self):
         """
@@ -106,10 +107,12 @@ class TestGetDefinedColorMap(unittest.TestCase):
         Test handling of list-based annotations,
         raises a NotImplementedError.
         """
-        obs = {'my_ann': pd.Series(['a', 'b', 'a']), 'my_ann_2': pd.Series(['a', 'b', 'a'])}
+        obs = {'my_ann': pd.Series(['a', 'b', 'a']),
+               'my_ann_2': pd.Series(['a', 'b', 'a'])}
         dummy = DummyAnnData(uns={'dummy': {}}, obs=obs)
+        annos_list = list(('my_ann', 'my_ann_2'))
         result = get_defined_color_map(dummy,
-                annotations=list(('my_ann', 'my_ann_2')))
+                                       annotations=annos_list)
         self.assertIsNotNone(result)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Summary:
This pull request allows the plotting of the spatial plot with multiple annotations.

Changes:

Add preparation of annotation data for labels on the colormap

Only this function failed to accept a list of strings, the rest of the function prepares the data correctly or accepts lists
Tests list acceptance
-Addition of unit test with set of annotations as list to show proper output