### PR TITLE
Rotate hist labels

### DIFF
--- a/src/spac/visualization.py
+++ b/src/spac/visualization.py
@@ -607,7 +607,7 @@ def histogram(adata, feature=None, annotation=None, layer=None,
                     group_data = plot_data[plot_data[group_by] == groups[i]]
 
                     sns.histplot(data=group_data, x=data_column,
-                     ax=ax_i, **kwargs)
+                                 ax=ax_i, **kwargs)
                     # If plotting feature specify which layer
                     if feature:
                         ax_i.set_title(f'{groups[i]} with Layer: {layer}')
@@ -652,7 +652,9 @@ def histogram(adata, feature=None, annotation=None, layer=None,
 
                 # Ajust top margin
                 hist.figure.subplots_adjust(left=.1,
-                 top=0.85, bottom=0.15, hspace=0.3)
+                                            top=0.85,
+                                            bottom=0.15,
+                                            hspace=0.3)
 
                 fig = hist.figure
                 axs.extend(hist.axes.flat)
@@ -689,7 +691,6 @@ def histogram(adata, feature=None, annotation=None, layer=None,
         if y_log_scale:
             ylabel = f'log({ylabel})'
         ax.set_ylabel(ylabel)
-        ax.tick_params(axis='x', rotation=90, labelsize=10)
 
     if len(axs) == 1:
         return fig, axs[0]

--- a/src/spac/visualization.py
+++ b/src/spac/visualization.py
@@ -651,7 +651,8 @@ def histogram(adata, feature=None, annotation=None, layer=None,
                 hist.set_titles("{col_name}")
 
                 # Ajust top margin
-                hist.figure.subplots_adjust(left=.1, top=0.85, bottom=0.15, hspace=0.3)
+                hist.figure.subplots_adjust(left=.1,
+                 top=0.85, bottom=0.15, hspace=0.3)
 
                 fig = hist.figure
                 axs.extend(hist.axes.flat)

--- a/src/spac/visualization.py
+++ b/src/spac/visualization.py
@@ -528,7 +528,8 @@ def histogram(adata, feature=None, annotation=None, layer=None,
 
     data_column = feature if feature else annotation
 
-    # Check for negative values and apply log1p transformation if x_log_scale is True
+    # Check for negative values
+    # apply log transformation if x_log_scale is True
     if x_log_scale:
         if (df[data_column] < 0).any():
             print(
@@ -558,7 +559,8 @@ def histogram(adata, feature=None, annotation=None, layer=None,
     ):
         bins = max(int(2*(num_rows ** (1/3))), 1)
         print(f'Automatically calculated number of bins is: {bins}')
-        return(bins)
+
+        return (bins)
 
     num_rows = plot_data.shape[0]
 
@@ -571,6 +573,7 @@ def histogram(adata, feature=None, annotation=None, layer=None,
     if group_by:
         groups = df[group_by].dropna().unique().tolist()
         n_groups = len(groups)
+
         if n_groups == 0:
             raise ValueError("There must be at least one group to create a"
                              " histogram.")
@@ -586,6 +589,7 @@ def histogram(adata, feature=None, annotation=None, layer=None,
             if feature:
                 ax.set_title(f'Layer: {layer}')
             axs.append(ax)
+
         else:
             if not facet:
                 fig, ax_array = plt.subplots(
@@ -632,25 +636,24 @@ def histogram(adata, feature=None, annotation=None, layer=None,
                     if y_log_scale:
                         ylabel = f'log({ylabel})'
                     ax_i.set_ylabel(ylabel)
-                    
                     axs.append(ax_i)
 
-                else:
-                    hist = sns.FacetGrid(plot_data, col=group_by)
-                    # Map the histogram function to the grid
-                    hist.map(sns.histplot, data_column, **kwargs)
+            else:
+                hist = sns.FacetGrid(plot_data, col=group_by)
+                # Map the histogram function to the grid
+                hist.map(sns.histplot, data_column, **kwargs)
 
-                    #set rotation of label
-                    hist.set_xticklabels(rotation=20, ha='right')
+                # Set rotation of label
+                hist.set_xticklabels(rotation=20, ha='right')
 
-                    #titles for each facet
-                    hist.set_titles("{col_name}")
+                # Titles for each facet
+                hist.set_titles("{col_name}")
 
-                    #ajust top margin
-                    hist.fig.subplots_adjust(left=.1, top=0.85, bottom=0.15, hspace=0.3)
+                # Ajust top margin
+                hist.fig.subplots_adjust(left=.1, top=0.85, bottom=0.15, hspace=0.3)
 
-                    fig = hist.fig
-                    axs.extend(hist.axes.flat)
+                fig = hist.fig
+                axs.extend(hist.axes.flat)
 
     else:
         sns.histplot(data=plot_data, x=data_column, ax=ax, **kwargs)

--- a/src/spac/visualization.py
+++ b/src/spac/visualization.py
@@ -606,7 +606,8 @@ def histogram(adata, feature=None, annotation=None, layer=None,
                 for i, ax_i in enumerate(ax_array):
                     group_data = plot_data[plot_data[group_by] == groups[i]]
 
-                    sns.histplot(data=group_data, x=data_column, ax=ax_i, **kwargs)
+                    sns.histplot(data=group_data, x=data_column,
+                     ax=ax_i, **kwargs)
                     # If plotting feature specify which layer
                     if feature:
                         ax_i.set_title(f'{groups[i]} with Layer: {layer}')
@@ -650,9 +651,9 @@ def histogram(adata, feature=None, annotation=None, layer=None,
                 hist.set_titles("{col_name}")
 
                 # Ajust top margin
-                hist.fig.subplots_adjust(left=.1, top=0.85, bottom=0.15, hspace=0.3)
+                hist.figure.subplots_adjust(left=.1, top=0.85, bottom=0.15, hspace=0.3)
 
-                fig = hist.fig
+                fig = hist.figure
                 axs.extend(hist.axes.flat)
 
     else:

--- a/tests/test_visualization/test_histogram.py
+++ b/tests/test_visualization/test_histogram.py
@@ -358,7 +358,7 @@ class TestHistogram(unittest.TestCase):
         # Using 2 * (n ** 1/3) heuristic for default bins
         expected_bins = max(int(2 * (self.adata.shape[0] ** (1 / 3))), 1)
         self.assertEqual(n_bins, expected_bins)
-    
+
     def test_facet_plot(self):
         """Test that facet plot works."""
         fig, ax = histogram(
@@ -367,10 +367,35 @@ class TestHistogram(unittest.TestCase):
             group_by='annotation2',
             facet=True,
         )
-        
+
         # Check if axs is a collection (list/array of Axes)
         self.assertIsInstance(ax, (list, np.ndarray),
-         "Output is not a multi-axis grid")
+                              "Output is not a multi-axis grid")
+
+        # Check number of facets equals number of unique groups
+        unique_groups = self.adata.obs['annotation2'].dropna().unique()
+        self.assertEqual(len(ax), len(unique_groups),
+                         f"Expected {len(unique_groups)}"
+                         f" facet plots, got {len(ax)}.")
+
+        # Validate each axis: title, xlabel, and ylabel
+        for i, axis in enumerate(ax):
+            # Check that title is set and matches the group
+            title = axis.get_title()
+            self.assertTrue(title, f"Facet {i} is missing a title.")
+            self.assertTrue(any(str(group) in title
+                            for group in unique_groups),
+                            f"Title '{title}' does not contain"
+                            f"any expected group names.")
+
+            # Check X and Y labels
+            self.assertIn('marker1', axis.get_xlabel(),
+                          f"Facet {i} X-axis label"
+                          f" '{axis.get_xlabel()}' is incorrect.")
+            self.assertIn(axis.get_ylabel(),
+                          ['Count', 'Frequency', 'Density', 'Probability'],
+                          f"Facet {i} Y-axis label"
+                          f" '{axis.get_ylabel()}' is not a valid stat.")
 
 
 if __name__ == '__main__':

--- a/tests/test_visualization/test_histogram.py
+++ b/tests/test_visualization/test_histogram.py
@@ -358,6 +358,18 @@ class TestHistogram(unittest.TestCase):
         # Using 2 * (n ** 1/3) heuristic for default bins
         expected_bins = max(int(2 * (self.adata.shape[0] ** (1 / 3))), 1)
         self.assertEqual(n_bins, expected_bins)
+    
+    def test_facet_plot(self):
+        """Test that facet plot works."""
+        fig, ax = histogram(
+            self.adata,
+            feature='marker1',
+            group_by='annotation2',
+            facet=True,
+        )
+        
+        # Check if axs is a collection (list/array of Axes)
+        self.assertIsInstance(ax, (list, np.ndarray), "Output is not a multi-axis grid")
 
 
 if __name__ == '__main__':

--- a/tests/test_visualization/test_histogram.py
+++ b/tests/test_visualization/test_histogram.py
@@ -369,7 +369,8 @@ class TestHistogram(unittest.TestCase):
         )
         
         # Check if axs is a collection (list/array of Axes)
-        self.assertIsInstance(ax, (list, np.ndarray), "Output is not a multi-axis grid")
+        self.assertIsInstance(ax, (list, np.ndarray),
+         "Output is not a multi-axis grid")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Summary
This PR adds the addition of the facet plot option in the function call of the histogram function as an alternative for group by. Additionally, all axis labels are rotated in the histogram function to avoid overlap. To test whether an facet plot is outputted there is a check on the axs output which is a list rather than a matplot axis.

Features
Facet Plots

Singular axis for columns of plots to prevent overlap and confusion when plotting
Rotation of Labels

Slight rotation of labels to prevent overlap in standard plot together and single plot scenarios