### PR TITLE
Fix Histogram Return Value

### DIFF
--- a/src/spac/visualization.py
+++ b/src/spac/visualization.py
@@ -753,9 +753,9 @@ def histogram(adata, feature=None, annotation=None, layer=None,
     ax.set_ylabel(ylabel)
 
     if len(axs) == 1:
-        return {"fig": fig, "axs": axs[0], "df": plot_data}
+        return {"fig": fig, "axs": axs[0], "df": hist_data}
     else:
-        return {"fig": fig, "axs": axs, "df": plot_data}
+        return {"fig": fig, "axs": axs, "df": hist_data}
 
 def heatmap(adata, column, layer=None, **kwargs):
     """


### PR DESCRIPTION
## Summary
This pull request alters `src/spac/visualization.py` by updating the return dictionary in the `calculate_histogram` function

## Changes
Corrections to return values:

* [`src/spac/visualization.py`](diffhunk://#diff-20e13a5111550712bb4f52c47c970e21f21d82299e3a2c5622eecc915abfd4bfL756-R758): Updated the return dictionary in the `calculate_histogram` function to return `hist_data` instead of `plot_data`.