### PR TITLE
Histogram facet plot

### DIFF
--- a/src/spac/visualization.py
+++ b/src/spac/visualization.py
@@ -681,13 +681,8 @@ def histogram(adata, feature=None, annotation=None, layer=None,
                                            groups[i]][data_column]
                     hist_data = calculate_histogram(group_data, kwargs['bins'])
 
-<<<<<<< HEAD
                     sns.histplot(data=hist_data, x="bin_center", ax=ax_i,
                                  weights='count', **kwargs)
-=======
-                    sns.histplot(data=group_data, x=data_column,
-                     ax=ax_i, **kwargs)
->>>>>>> 11127cf (formatting of facet plot, and unittest)
                     # If plotting feature specify which layer
                     if feature:
                         ax_i.set_title(f'{groups[i]} with Layer: {layer}')

--- a/src/spac/visualization.py
+++ b/src/spac/visualization.py
@@ -778,7 +778,6 @@ def histogram(adata, feature=None, annotation=None, layer=None,
         if y_log_scale:
             ylabel = f'log({ylabel})'
         ax.set_ylabel(ylabel)
-        ax.tick_params(axis='x', rotation=90, labelsize=10)
 
     if len(axs) == 1:
         return {"fig": fig, "axs": axs[0], "df": plot_data}

--- a/src/spac/visualization.py
+++ b/src/spac/visualization.py
@@ -563,7 +563,8 @@ def histogram(adata, feature=None, annotation=None, layer=None,
     ):
         bins = max(int(2*(num_rows ** (1/3))), 1)
         print(f'Automatically calculated number of bins is: {bins}')
-        return(bins)
+
+        return (bins)
 
     num_rows = plot_data.shape[0]
 
@@ -625,6 +626,7 @@ def histogram(adata, feature=None, annotation=None, layer=None,
     if group_by:
         groups = df[group_by].dropna().unique().tolist()
         n_groups = len(groups)
+
         if n_groups == 0:
             raise ValueError("There must be at least one group to create a"
                              " histogram.")
@@ -660,6 +662,7 @@ def histogram(adata, feature=None, annotation=None, layer=None,
             if feature:
                 ax.set_title(f'Layer: {layer}')
             axs.append(ax)
+
         else:
             if not facet:
                 fig, ax_array = plt.subplots(
@@ -709,7 +712,6 @@ def histogram(adata, feature=None, annotation=None, layer=None,
                     if y_log_scale:
                         ylabel = f'log({ylabel})'
                     ax_i.set_ylabel(ylabel)
-
                     axs.append(ax_i)
             else:
                 hist = sns.FacetGrid(plot_data, col=group_by)

--- a/src/spac/visualization.py
+++ b/src/spac/visualization.py
@@ -398,7 +398,7 @@ def tsne_plot(adata, color_column=None, ax=None, **kwargs):
 
 def histogram(adata, feature=None, annotation=None, layer=None,
               group_by=None, together=False, ax=None,
-              x_log_scale=False, y_log_scale=False, **kwargs):
+              x_log_scale=False, y_log_scale=False, facet=False, **kwargs):
     """
     Plot the histogram of cells based on a specific feature from adata.X
     or annotation from adata.obs.
@@ -439,6 +439,9 @@ def histogram(adata, feature=None, annotation=None, layer=None,
 
     y_log_scale : bool, default False
         If True, the y-axis will be set to log scale.
+
+    facet : bool, default False
+        If True, group by function outputs facet plots
 
     **kwargs
         Additional keyword arguments passed to seaborn histplot function.
@@ -612,7 +615,7 @@ def histogram(adata, feature=None, annotation=None, layer=None,
         else:
             counts = data.value_counts().sort_index()
             return pd.DataFrame({
-                'bin_center': counts.index, 
+                'bin_center': counts.index,
                 'bin_left': counts.index,
                 'bin_right': counts.index,
                 'count': counts.values
@@ -641,7 +644,7 @@ def histogram(adata, feature=None, annotation=None, layer=None,
                 group_data = plot_data[
                     plot_data[group_by] == group
                 ][data_column]
-                group_hist = calculate_histogram(group_data, kwargs['bins'], 
+                group_hist = calculate_histogram(group_data, kwargs['bins'],
                                                  bin_edges=global_bin_edges)
                 group_hist[group_by] = group
                 hist_data.append(group_hist)
@@ -651,111 +654,135 @@ def histogram(adata, feature=None, annotation=None, layer=None,
             kwargs.setdefault("multiple", "stack")
             kwargs.setdefault("element", "bars")
 
-            
-            sns.histplot(data=hist_data, x='bin_center', weights='count', 
+            sns.histplot(data=hist_data, x='bin_center', weights='count',
                          hue=group_by, ax=ax, **kwargs)
             # If plotting feature specify which layer
             if feature:
                 ax.set_title(f'Layer: {layer}')
             axs.append(ax)
         else:
-            fig, ax_array = plt.subplots(
-                n_groups, 1, figsize=(5, 5 * n_groups)
-            )
+            if not facet:
+                fig, ax_array = plt.subplots(
+                    n_groups, 1, figsize=(5, 5 * n_groups)
+                )
 
-            # Convert a single Axes object to a list
-            # Ensure ax_array is always iterable
-            if n_groups == 1:
-                ax_array = [ax_array]
+                # Convert a single Axes object to a list
+                # Ensure ax_array is always iterable
+                if n_groups == 1:
+                    ax_array = [ax_array]
+                else:
+                    ax_array = ax_array.flatten()
+
+                for i, ax_i in enumerate(ax_array):
+                    group_data = plot_data[plot_data[group_by] ==
+                                           groups[i]][data_column]
+                    hist_data = calculate_histogram(group_data, kwargs['bins'])
+
+                    sns.histplot(data=hist_data, x="bin_center", ax=ax_i,
+                                 weights='count', **kwargs)
+                    # If plotting feature specify which layer
+                    if feature:
+                        ax_i.set_title(f'{groups[i]} with Layer: {layer}')
+                    else:
+                        ax_array = ax_array.flatten()
+
+                    # Set axis scales if y_log_scale is True
+                    if y_log_scale:
+                        ax_i.set_yscale('log')
+
+                    # Adjust x-axis label if x_log_scale is True
+                    if x_log_scale:
+                        xlabel = f'log({data_column})'
+                    else:
+                        xlabel = data_column
+                    ax_i.set_xlabel(xlabel)
+
+                    # Adjust y-axis label based on 'stat' parameter
+                    stat = kwargs.get('stat', 'count')
+                    ylabel_map = {
+                        'count': 'Count',
+                        'frequency': 'Frequency',
+                        'density': 'Density',
+                        'probability': 'Probability'
+                    }
+                    ylabel = ylabel_map.get(stat, 'Count')
+                    if y_log_scale:
+                        ylabel = f'log({ylabel})'
+                    ax_i.set_ylabel(ylabel)
+
+                    axs.append(ax_i)
             else:
-                ax_array = ax_array.flatten()
+                hist = sns.FacetGrid(plot_data, col=group_by)
+                # Map the histogram function to the grid
+                hist.map(sns.histplot, data_column, **kwargs)
 
-            for i, ax_i in enumerate(ax_array):
-                group_data = plot_data[plot_data[group_by] == 
-                             groups[i]][data_column]
-                hist_data = calculate_histogram(group_data, kwargs['bins'])
+                # Set rotation of label
+                hist.set_xticklabels(rotation=20, ha='right')
 
-                sns.histplot(data=hist_data, x="bin_center", ax=ax_i, 
-                    weights='count', **kwargs)
-                # If plotting feature specify which layer
-                if feature:
-                    ax_i.set_title(f'{groups[i]} with Layer: {layer}')
-                else:
-                    ax_i.set_title(f'{groups[i]}')
+                # Titles for each facet
+                hist.set_titles("{col_name}")
 
-                # Set axis scales if y_log_scale is True
-                if y_log_scale:
-                    ax_i.set_yscale('log')
+                # Ajust top margin
+                hist.figure.subplots_adjust(left=.1,
+                                            top=0.85,
+                                            bottom=0.15,
+                                            hspace=0.3)
 
-                # Adjust x-axis label if x_log_scale is True
-                if x_log_scale:
-                    xlabel = f'log({data_column})'
-                else:
-                    xlabel = data_column
-                ax_i.set_xlabel(xlabel)
+                fig = hist.figure
+                axs.extend(hist.axes.flat)
 
-                # Adjust y-axis label based on 'stat' parameter
-                stat = kwargs.get('stat', 'count')
-                ylabel_map = {
-                    'count': 'Count',
-                    'frequency': 'Frequency',
-                    'density': 'Density',
-                    'probability': 'Probability'
-                }
-                ylabel = ylabel_map.get(stat, 'Count')
-                if y_log_scale:
-                    ylabel = f'log({ylabel})'
-                ax_i.set_ylabel(ylabel)
-
-                axs.append(ax_i)
     else:
         # Precompute histogram data for single plot
         hist_data = calculate_histogram(plot_data[data_column], kwargs['bins'])
         if pd.api.types.is_numeric_dtype(plot_data[data_column]):
-            ax.set_xlim(hist_data['bin_left'].min(), 
-            hist_data['bin_right'].max())
-        
+            ax.set_xlim(hist_data['bin_left'].min(),
+                        hist_data['bin_right'].max())
+
         sns.histplot(
-            data=hist_data, 
+            data=hist_data,
             x='bin_center',
-            weights="count", 
-            ax=ax, 
+            weights="count",
+            ax=ax,
             **kwargs
         )
-        
+
         # If plotting feature specify which layer
         if feature:
             ax.set_title(f'Layer: {layer}')
         axs.append(ax)
 
-    # Set axis scales if y_log_scale is True
-    if y_log_scale:
-        ax.set_yscale('log')
+    axes = axs if isinstance(axs, (list, np.ndarray)) else [axs]
+    for ax in axes:
+        # Set axis scales if y_log_scale is True
+        if y_log_scale:
+            ax.set_yscale('log')
 
-    # Adjust x-axis label if x_log_scale is True
-    if x_log_scale:
-        xlabel = f'log({data_column})'
-    else:
-        xlabel = data_column
-    ax.set_xlabel(xlabel)
+        # Adjust x-axis label if x_log_scale is True
+        if x_log_scale:
+            xlabel = f'log({data_column})'
+        else:
+            xlabel = data_column
+        ax.set_xlabel(xlabel)
 
-    # Adjust y-axis label based on 'stat' parameter
-    stat = kwargs.get('stat', 'count')
-    ylabel_map = {
-        'count': 'Count',
-        'frequency': 'Frequency',
-        'density': 'Density',
-        'probability': 'Probability'
-    }
-    ylabel = ylabel_map.get(stat, 'Count')
-    if y_log_scale:
-        ylabel = f'log({ylabel})'
-    ax.set_ylabel(ylabel)
+        # Adjust y-axis label based on 'stat' parameter
+        stat = kwargs.get('stat', 'count')
+        ylabel_map = {
+            'count': 'Count',
+            'frequency': 'Frequency',
+            'density': 'Density',
+            'probability': 'Probability'
+        }
+        ylabel = ylabel_map.get(stat, 'Count')
+        if y_log_scale:
+            ylabel = f'log({ylabel})'
+        ax.set_ylabel(ylabel)
+        ax.tick_params(axis='x', rotation=90, labelsize=10)
 
     if len(axs) == 1:
         return {"fig": fig, "axs": axs[0], "df": plot_data}
     else:
         return {"fig": fig, "axs": axs, "df": plot_data}
+
 
 def heatmap(adata, column, layer=None, **kwargs):
     """

--- a/src/spac/visualization.py
+++ b/src/spac/visualization.py
@@ -681,8 +681,13 @@ def histogram(adata, feature=None, annotation=None, layer=None,
                                            groups[i]][data_column]
                     hist_data = calculate_histogram(group_data, kwargs['bins'])
 
+<<<<<<< HEAD
                     sns.histplot(data=hist_data, x="bin_center", ax=ax_i,
                                  weights='count', **kwargs)
+=======
+                    sns.histplot(data=group_data, x=data_column,
+                     ax=ax_i, **kwargs)
+>>>>>>> 11127cf (formatting of facet plot, and unittest)
                     # If plotting feature specify which layer
                     if feature:
                         ax_i.set_title(f'{groups[i]} with Layer: {layer}')

--- a/tests/test_visualization/test_histogram.py
+++ b/tests/test_visualization/test_histogram.py
@@ -412,6 +412,18 @@ class TestHistogram(unittest.TestCase):
         # Using 2 * (n ** 1/3) heuristic for default bins
         expected_bins = max(int(2 * (self.adata.shape[0] ** (1 / 3))), 1)
         self.assertEqual(n_bins, expected_bins)
+    
+    def test_facet_plot(self):
+        """Test that facet plot works."""
+        fig, ax = histogram(
+            self.adata,
+            feature='marker1',
+            group_by='annotation2',
+            facet=True,
+        )
+        
+        # Check if axs is a collection (list/array of Axes)
+        self.assertIsInstance(ax, (list, np.ndarray), "Output is not a multi-axis grid")
 
     def test_facet_plot(self):
         """Test that facet plot works."""

--- a/tests/test_visualization/test_histogram.py
+++ b/tests/test_visualization/test_histogram.py
@@ -412,7 +412,7 @@ class TestHistogram(unittest.TestCase):
         # Using 2 * (n ** 1/3) heuristic for default bins
         expected_bins = max(int(2 * (self.adata.shape[0] ** (1 / 3))), 1)
         self.assertEqual(n_bins, expected_bins)
-    
+
     def test_facet_plot(self):
         """Test that facet plot works."""
         fig, ax = histogram(
@@ -421,10 +421,35 @@ class TestHistogram(unittest.TestCase):
             group_by='annotation2',
             facet=True,
         )
-        
+
         # Check if axs is a collection (list/array of Axes)
         self.assertIsInstance(ax, (list, np.ndarray),
-         "Output is not a multi-axis grid")
+                              "Output is not a multi-axis grid")
+
+        # Check number of facets equals number of unique groups
+        unique_groups = self.adata.obs['annotation2'].dropna().unique()
+        self.assertEqual(len(ax), len(unique_groups),
+                         f"Expected {len(unique_groups)}"
+                         f" facet plots, got {len(ax)}.")
+
+        # Validate each axis: title, xlabel, and ylabel
+        for i, axis in enumerate(ax):
+            # Check that title is set and matches the group
+            title = axis.get_title()
+            self.assertTrue(title, f"Facet {i} is missing a title.")
+            self.assertTrue(any(str(group) in title
+                            for group in unique_groups),
+                            f"Title '{title}' does not contain"
+                            f"any expected group names.")
+
+            # Check X and Y labels
+            self.assertIn('marker1', axis.get_xlabel(),
+                          f"Facet {i} X-axis label"
+                          f" '{axis.get_xlabel()}' is incorrect.")
+            self.assertIn(axis.get_ylabel(),
+                          ['Count', 'Frequency', 'Density', 'Probability'],
+                          f"Facet {i} Y-axis label"
+                          f" '{axis.get_ylabel()}' is not a valid stat.")
 
     def test_facet_plot(self):
         """Test that facet plot works."""

--- a/tests/test_visualization/test_histogram.py
+++ b/tests/test_visualization/test_histogram.py
@@ -423,7 +423,8 @@ class TestHistogram(unittest.TestCase):
         )
         
         # Check if axs is a collection (list/array of Axes)
-        self.assertIsInstance(ax, (list, np.ndarray), "Output is not a multi-axis grid")
+        self.assertIsInstance(ax, (list, np.ndarray),
+         "Output is not a multi-axis grid")
 
     def test_facet_plot(self):
         """Test that facet plot works."""

--- a/tests/test_visualization/test_histogram.py
+++ b/tests/test_visualization/test_histogram.py
@@ -222,7 +222,7 @@ class TestHistogram(unittest.TestCase):
 
     def test_y_log_scale_label(self):
         """Test that y-axis label is updated when y_log_scale is True."""
-        fig, ax, dfd = histogram(
+        fig, ax, df = histogram(
             self.adata, 
             feature='marker1', 
             y_log_scale=True
@@ -412,6 +412,44 @@ class TestHistogram(unittest.TestCase):
         # Using 2 * (n ** 1/3) heuristic for default bins
         expected_bins = max(int(2 * (self.adata.shape[0] ** (1 / 3))), 1)
         self.assertEqual(n_bins, expected_bins)
+
+    def test_facet_plot(self):
+        """Test that facet plot works."""
+        fig, ax, df = histogram(
+            self.adata,
+            feature='marker1',
+            group_by='annotation2',
+            facet=True,
+        ).values()
+
+        # Check if axs is a collection (list/array of Axes)
+        self.assertIsInstance(ax, (list, np.ndarray),
+                              "Output is not a multi-axis grid")
+
+        # Check number of facets equals number of unique groups
+        unique_groups = self.adata.obs['annotation2'].dropna().unique()
+        self.assertEqual(len(ax), len(unique_groups),
+                         f"Expected {len(unique_groups)}"
+                         f" facet plots, got {len(ax)}.")
+
+        # Validate each axis: title, xlabel, and ylabel
+        for i, axis in enumerate(ax):
+            # Check that title is set and matches the group
+            title = axis.get_title()
+            self.assertTrue(title, f"Facet {i} is missing a title.")
+            self.assertTrue(any(str(group) in title
+                            for group in unique_groups),
+                            f"Title '{title}' does not contain"
+                            f"any expected group names.")
+
+            # Check X and Y labels
+            self.assertIn('marker1', axis.get_xlabel(),
+                          f"Facet {i} X-axis label"
+                          f" '{axis.get_xlabel()}' is incorrect.")
+            self.assertIn(axis.get_ylabel(),
+                          ['Count', 'Frequency', 'Density', 'Probability'],
+                          f"Facet {i} Y-axis label"
+                          f" '{axis.get_ylabel()}' is not a valid stat.")
 
 
 if __name__ == '__main__':

--- a/tests/test_visualization/test_histogram.py
+++ b/tests/test_visualization/test_histogram.py
@@ -415,44 +415,6 @@ class TestHistogram(unittest.TestCase):
 
     def test_facet_plot(self):
         """Test that facet plot works."""
-        fig, ax = histogram(
-            self.adata,
-            feature='marker1',
-            group_by='annotation2',
-            facet=True,
-        )
-
-        # Check if axs is a collection (list/array of Axes)
-        self.assertIsInstance(ax, (list, np.ndarray),
-                              "Output is not a multi-axis grid")
-
-        # Check number of facets equals number of unique groups
-        unique_groups = self.adata.obs['annotation2'].dropna().unique()
-        self.assertEqual(len(ax), len(unique_groups),
-                         f"Expected {len(unique_groups)}"
-                         f" facet plots, got {len(ax)}.")
-
-        # Validate each axis: title, xlabel, and ylabel
-        for i, axis in enumerate(ax):
-            # Check that title is set and matches the group
-            title = axis.get_title()
-            self.assertTrue(title, f"Facet {i} is missing a title.")
-            self.assertTrue(any(str(group) in title
-                            for group in unique_groups),
-                            f"Title '{title}' does not contain"
-                            f"any expected group names.")
-
-            # Check X and Y labels
-            self.assertIn('marker1', axis.get_xlabel(),
-                          f"Facet {i} X-axis label"
-                          f" '{axis.get_xlabel()}' is incorrect.")
-            self.assertIn(axis.get_ylabel(),
-                          ['Count', 'Frequency', 'Density', 'Probability'],
-                          f"Facet {i} Y-axis label"
-                          f" '{axis.get_ylabel()}' is not a valid stat.")
-
-    def test_facet_plot(self):
-        """Test that facet plot works."""
         fig, ax, df = histogram(
             self.adata,
             feature='marker1',


### PR DESCRIPTION
Summary
This PR adds the addition of the facet plot option in the function call of the histogram function as an alternative for group by. Additionally, all axis labels are rotated in the histogram function to avoid overlap. To test whether a facet plot is outputted there is a check on the axs output which is a list rather than a matplot axis. Additionally, there are checks for the axis labels and titles.