### PR TITLE
Adding Pin_Colors to Histogram

### DIFF
--- a/oryx-build-commands.txt
+++ b/oryx-build-commands.txt
@@ -1,0 +1,2 @@
+PlatformWithVersion=Python 
+BuildCommands=conda env create --file environment.yml --prefix ./venv --quiet

--- a/oryx-build-commands.txt
+++ b/oryx-build-commands.txt
@@ -1,2 +1,0 @@
-PlatformWithVersion=Python 
-BuildCommands=conda env create --file environment.yml --prefix ./venv --quiet

--- a/src/spac/visualization.py
+++ b/src/spac/visualization.py
@@ -398,7 +398,8 @@ def tsne_plot(adata, color_column=None, ax=None, **kwargs):
 
 def histogram(adata, feature=None, annotation=None, layer=None,
               group_by=None, together=False, ax=None,
-              x_log_scale=False, y_log_scale=False, **kwargs):
+              x_log_scale=False, y_log_scale=False,
+              defined_color_map=None, **kwargs):
     """
     Plot the histogram of cells based on a specific feature from adata.X
     or annotation from adata.obs.
@@ -439,6 +440,10 @@ def histogram(adata, feature=None, annotation=None, layer=None,
 
     y_log_scale : bool, default False
         If True, the y-axis will be set to log scale.
+    
+    defined_color_map : str, optional, default=None
+        Key in adata.uns used to retrieve a color mapping dictionary to
+        color code the histogram.
 
     **kwargs
         Additional keyword arguments passed to seaborn histplot function.
@@ -488,7 +493,6 @@ def histogram(adata, feature=None, annotation=None, layer=None,
             DataFrame containing the data used for plotting the histogram.
 
     """
-
     # If no feature or annotation is specified, apply default behavior
     if feature is None and annotation is None:
         # Default to the first feature in adata.var_names
@@ -522,6 +526,10 @@ def histogram(adata, feature=None, annotation=None, layer=None,
         layer = 'Original'
 
     df = pd.concat([df, adata.obs], axis=1)
+
+    if defined_color_map:
+        color_dict = get_defined_color_map(adata,defined_color_map)
+        kwargs.setdefault("palette", color_dict)
 
     if feature and annotation:
         raise ValueError("Cannot pass both feature and annotation,"
@@ -651,7 +659,6 @@ def histogram(adata, feature=None, annotation=None, layer=None,
             kwargs.setdefault("multiple", "stack")
             kwargs.setdefault("element", "bars")
 
-            
             sns.histplot(data=hist_data, x='bin_center', weights='count', 
                          hue=group_by, ax=ax, **kwargs)
             # If plotting feature specify which layer
@@ -671,12 +678,18 @@ def histogram(adata, feature=None, annotation=None, layer=None,
                 ax_array = ax_array.flatten()
 
             for i, ax_i in enumerate(ax_array):
-                group_data = plot_data[plot_data[group_by] == 
-                             groups[i]][data_column]
+                group = groups[i]
+                group_data = plot_data[plot_data[group_by] == group][data_column]
                 hist_data = calculate_histogram(group_data, kwargs['bins'])
-
+                
+                # Retrieve the specific color for this group if defined_color_map is provided
+                group_color = None
+                if defined_color_map:
+                    group_color = color_dict.get(group, None)
+                
                 sns.histplot(data=hist_data, x="bin_center", ax=ax_i, 
-                    weights='count', **kwargs)
+                            weights='count', color=group_color, **kwargs)
+                
                 # If plotting feature specify which layer
                 if feature:
                     ax_i.set_title(f'{groups[i]} with Layer: {layer}')
@@ -713,8 +726,14 @@ def histogram(adata, feature=None, annotation=None, layer=None,
         hist_data = calculate_histogram(plot_data[data_column], kwargs['bins'])
         if pd.api.types.is_numeric_dtype(plot_data[data_column]):
             ax.set_xlim(hist_data['bin_left'].min(), 
-            hist_data['bin_right'].max())
-        
+                        hist_data['bin_right'].max())
+
+        # Set default color from custom color map if available
+        if defined_color_map:
+            color_dict = get_defined_color_map(adata,defined_color_map)
+            default_color = list(color_dict.values())[0]
+            kwargs['color'] = default_color
+
         sns.histplot(
             data=hist_data, 
             x='bin_center',

--- a/src/spac/visualization.py
+++ b/src/spac/visualization.py
@@ -679,10 +679,14 @@ def histogram(adata, feature=None, annotation=None, layer=None,
 
             for i, ax_i in enumerate(ax_array):
                 group = groups[i]
-                group_data = plot_data[plot_data[group_by] == group][data_column]
-                hist_data = calculate_histogram(group_data, kwargs['bins'])
+                group_data = plot_data[plot_data[group_by] == group][
+                    data_column
+                ]
+                hist_data = calculate_histogram(
+                    group_data, kwargs['bins']
+                )
                 
-                # Retrieve the specific color for this group if defined_color_map is provided
+                #If defined_color_map provided, retrieves color map
                 group_color = None
                 if defined_color_map:
                     group_color = color_dict.get(group, None)


### PR DESCRIPTION
### Summary:
This pull request includes changes to src/spac/visualization.py file to enhance the color-coding of the histogram function. It allows users to use the custom pin_colors stored in the ann-data object.

### Changes:
- Added optional input to function defined_color_map, which contains the key for the get_defined_color_map function to grab.