### PR TITLE
fix(summarize_dataframe): remove duplicated missing index

### DIFF
--- a/src/spac/data_utils.py
+++ b/src/spac/data_utils.py
@@ -1151,6 +1151,7 @@ def summarize_dataframe(
         A dictionary where each key is a column name and its value is another
         dictionary with:
           - 'data_type': either 'numeric' or 'categorical'
+          - 'missing_count': int
           - 'missing_indices': list of row indices with missing values
           - 'summary': summary statistics if numeric or unique labels with
           counts if categorical
@@ -1205,7 +1206,7 @@ def summarize_dataframe(
         print(f"Summary for column '{col}':")
         print(f"Type: {col_info['data_type']}")
         print("Count missing indices:", col_info['count_missing_indices'])
-        print("Missing indices:", col_info['missing_indices'])
+        # print("Missing indices:", col_info['missing_indices'])
         print("Details:", col_info['summary'])
         print("-" * 40)
     return results


### PR DESCRIPTION
The original code still prints the list of row indices even when print_nan_locations is  False. It also prints the indices twice when it is True (message + summary), which clutters the log if tens of thousands of rows are missing, dumping all indices to the console can overwhelm CI log.

I have refactored the function code by commenting out the duplicated line that prints the index list inside the summary block, so keeps logs concise, preserves full detail when requested.
It affects only the console output—it does not change what the function returns. Therefore this unit test assertion remains valid.