### PR TITLE
feat(downsample):AnnData input and output for downsample_cells

### DIFF
--- a/src/spac/data_utils.py
+++ b/src/spac/data_utils.py
@@ -705,8 +705,8 @@ def _get_downsampled_indexes(cell_data, annotations,
 
     # Combine annotations into a single column if multiple annotations
     if len(annotations) > 1:
-        grouping_col = cell_data[annotations].apply(
-            lambda row: '_'.join(row.values.astype(str)), axis=1)
+        cell_data[combined_col_name] = cell_data[annotations].astype(str).agg('_'.join, axis=1)
+        grouping_col = combined_col_name
     else:
         grouping_col = annotations[0]
 

--- a/tests/test_data_utils/test_downsample_cells.py
+++ b/tests/test_data_utils/test_downsample_cells.py
@@ -221,8 +221,7 @@ class TestDownsampleCells(unittest.TestCase):
             n_samples = 1,
             stratify = False,
             rand = True,
-            combined_col_name= '_combined_',
-            min_threshold= 5
+            combined_col_name= '_combined_'
         )
     
         # confirm the downsampled_df is an anndata object


### PR DESCRIPTION
Summary:
Modified downsample_cells function to accept anndata.AnnData objects as input. When an AnnData object is provided, .X and .obs data are combined into a pandas DataFrame, before applying the rest of the downsampling function.

Changes:

- Added code to convert anndata objects into pandas dataframes
- Returns error message if input is neither an anndata object or pandas dataframe
- Created unit test to check anndata object is correctly processes

