### PR TITLE
Fix PhenoGraph Galaxy runtime issues

### DIFF
--- a/src/spac/templates/template_utils.py
+++ b/src/spac/templates/template_utils.py
@@ -3,7 +3,6 @@ import pickle
 from typing import Any, Dict, Union, Optional, List
 import json
 import pandas as pd
-import anndata as ad
 import re
 import logging
 import matplotlib.pyplot as plt
@@ -33,8 +32,10 @@ def load_input(file_path: Union[str, Path]):
     suffix = path.suffix.lower()
 
     if suffix in ['.h5ad', '.h5']:
-        # Load h5ad file
+        # Lazy import so pickle-only workflows can import this module in
+        # environments that do not ship anndata, such as the RAPIDS env.
         try:
+            import anndata as ad
             return ad.read_h5ad(path)
         except ImportError:
             raise ImportError(
@@ -45,24 +46,42 @@ def load_input(file_path: Union[str, Path]):
 
     elif suffix in ['.pickle', '.pkl', '.p']:
         # Load pickle file
-        with path.open('rb') as fh:
-            return pickle.load(fh)
+        return _load_pickle(path)
 
     else:
         # Try to detect file type by content
         try:
             # First try h5ad
+            import anndata as ad
             return ad.read_h5ad(path)
         except Exception:
             # Fall back to pickle
             try:
-                with path.open('rb') as fh:
-                    return pickle.load(fh)
+                return _load_pickle(path)
             except Exception as e:
                 raise ValueError(
                     f"Unable to load file '{file_path}'. "
                     f"Supported formats: h5ad, pickle. Error: {e}"
                 )
+
+
+def _load_pickle(path: Path):
+    """Load pickle data, with a clear error for AnnData pickles."""
+    try:
+        with path.open('rb') as fh:
+            return pickle.load(fh)
+    except ModuleNotFoundError as e:
+        missing_module = getattr(e, "name", None) or ""
+        is_anndata_missing = (
+            missing_module == "anndata" or
+            missing_module.startswith("anndata.") or
+            "No module named 'anndata'" in str(e)
+        )
+        if is_anndata_missing:
+            raise ImportError(
+                "anndata package required to read AnnData pickle files"
+            ) from e
+        raise
 
 
 def save_results(

--- a/src/spac/transform/clustering/phenograph/cpu.py
+++ b/src/spac/transform/clustering/phenograph/cpu.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 import time
 from typing import List, Optional
 
+import pandas as pd
+
 from .preprocess import prepare_features
 
 
@@ -81,7 +83,11 @@ def phenograph_cpu(
     )
     elapsed = time.time() - t0
 
-    adata.obs[output_annotation] = communities.astype("category")
+    adata.obs[output_annotation] = pd.Series(
+        communities,
+        index=adata.obs.index,
+        name=output_annotation,
+    ).astype("category")
 
     # Provenance — makes it easy to distinguish old vs. new CPU path downstream.
     adata.uns.setdefault("phenograph_clustering_cpu", {}).update(

--- a/tests/templates/test_template_utils_lazy_import.py
+++ b/tests/templates/test_template_utils_lazy_import.py
@@ -1,0 +1,87 @@
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+def _repo_env(repo_root: Path):
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(repo_root / "src")
+    return env
+
+
+def _block_anndata_script(body: str) -> str:
+    return textwrap.dedent(
+        f"""
+        import importlib.abc
+        import sys
+
+        class BlockAnndata(importlib.abc.MetaPathFinder):
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname == "anndata" or fullname.startswith("anndata."):
+                    raise ModuleNotFoundError("No module named 'anndata'")
+                return None
+
+        sys.meta_path.insert(0, BlockAnndata())
+
+        {body}
+        """
+    )
+
+
+def test_template_utils_import_does_not_require_anndata():
+    repo_root = Path(__file__).resolve().parents[2]
+
+    script = _block_anndata_script(
+        """
+        from spac.templates.template_utils import parse_params
+
+        assert parse_params({"ok": True})["ok"] is True
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=repo_root,
+        env=_repo_env(repo_root),
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_anndata_pickle_without_anndata_has_clear_error(tmp_path):
+    import pickle
+
+    import anndata as ad
+    import numpy as np
+
+    repo_root = Path(__file__).resolve().parents[2]
+    pickle_path = tmp_path / "adata.pickle"
+    with pickle_path.open("wb") as fh:
+        pickle.dump(ad.AnnData(X=np.ones((2, 2), dtype=np.float32)), fh)
+
+    script = _block_anndata_script(
+        f"""
+        from spac.templates.template_utils import load_input
+
+        try:
+            load_input({str(pickle_path)!r})
+        except ImportError as e:
+            assert "anndata package required to read AnnData pickle files" in str(e)
+        else:
+            raise AssertionError("expected ImportError")
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=repo_root,
+        env=_repo_env(repo_root),
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/tests/test_transform/clustering/phenograph/test_cpu.py
+++ b/tests/test_transform/clustering/phenograph/test_cpu.py
@@ -1,0 +1,60 @@
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+from anndata import AnnData
+
+sys.path.append(str(Path(__file__).resolve().parents[4] / "src"))
+
+from spac.transform.clustering.phenograph.cpu import phenograph_cpu
+
+
+class TestPhenographCPU(unittest.TestCase):
+    def test_numpy_communities_are_saved_as_aligned_categorical(self):
+        obs_index = ["cell-c", "cell-a", "cell-b"]
+        adata = AnnData(
+            X=np.array(
+                [
+                    [1.0, 0.1],
+                    [0.9, 0.2],
+                    [0.1, 1.1],
+                ],
+                dtype=np.float32,
+            ),
+            obs=pd.DataFrame(index=obs_index),
+            var=pd.DataFrame(index=["marker_a", "marker_b"]),
+        )
+
+        def fake_cluster(data, **kwargs):
+            return np.array([2, 2, 1]), None, 0.75
+
+        fake_phenograph = types.SimpleNamespace(cluster=fake_cluster)
+
+        with patch.dict(sys.modules, {"phenograph": fake_phenograph}):
+            result = phenograph_cpu(
+                adata,
+                k=2,
+                seed=42,
+                output_annotation="phenograph",
+            )
+
+        self.assertIs(result, adata)
+        self.assertEqual(list(adata.obs.index), obs_index)
+        self.assertIn("phenograph", adata.obs)
+        self.assertIsInstance(
+            adata.obs["phenograph"].dtype,
+            pd.CategoricalDtype,
+        )
+        self.assertEqual(list(adata.obs["phenograph"]), [2, 2, 1])
+        self.assertEqual(
+            adata.uns["phenograph_clustering_cpu"]["modularity"],
+            0.75,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-# Dockerfile.v0.9.2 — nciccbr/spac:v0.9.2
+# Dockerfile.v0.9.3 — nciccbr/spac:v0.9.3
 #
 # SPAC CPU image for AWS Galaxy. Adds the new CPU PhenoGraph path
 # (spac.transform.clustering.phenograph.cpu) that lives on the
@@ -7,24 +7,17 @@
 # phenograph_clustering.xml Galaxy tool uses.
 #
 # =============================================================================
-# Relationship to v0.9.1
+# Relationship to v0.9.2
 # -----------------------------------------------------------------------------
-# This file is a minimal fork of the validated v0.9.1 Dockerfile. The only
+# This file is a minimal patch fork of the validated v0.9.2 Dockerfile. The only
 # substantive differences are:
 #
-#   1. LABEL version bumped 0.9.1 -> 0.9.2
-#   2. ARG GITHUB_BRANCH default flipped from "main" to the feature branch,
-#      because the new spac.transform.clustering.phenograph.cpu module and
-#      the new phenograph_clustering_cpu_template have not merged to main yet.
-#      (Once the SCSAWorkflow PR merges and a tag is cut, bump this to the
-#       release tag.)
-#   3. Build-time verification tests (the RUN "=== VERIFYING SPAC INSTALLATION")
-#      extended with one extra check for the new CPU module, so Dockers2 CI
-#      catches any regression in the refactored code at build time rather than
-#      at Galaxy runtime.
+#   1. LABEL version bumped 0.9.2 -> 0.9.3
+#   2. GITHUB_BRANCH remains on feature/phenograph-gpu-refactor so the image
+#      picks up the PhenoGraph CPU wrapper fix for NumPy community labels.
 #
 # Everything else — curl-based environment.yml fetch, --no-deps pip install,
-# channel config, env variables, CMD — is copied verbatim from v0.9.1 to
+# channel config, env variables, CMD — is copied verbatim from v0.9.2 to
 # minimize behavior drift and stay within the known-good CCBR/Dockers2 pattern.
 #
 # Why curl and not COPY?
@@ -43,14 +36,14 @@ FROM continuumio/miniconda3:24.3.0-0
 ARG ENV_NAME=spac
 # Default to the feature branch until the PhenoGraph GPU refactor merges
 # to SCSAWorkflow main and a release is tagged. Bump to the tag (e.g.
-# v0.9.2 on SCSAWorkflow) once that happens.
+# v0.9.3 on SCSAWorkflow) once that happens.
 ARG GITHUB_BRANCH=feature/phenograph-gpu-refactor
 ARG GITHUB_REPO=FNLCR-DMAP/SCSAWorkflow
 
 # Set labels
 LABEL maintainer="FNLCR-DMAP"
 LABEL description="SPAC - Single Cell Spatial Analysis Container"
-LABEL version="0.9.2"
+LABEL version="0.9.3"
 LABEL github.branch="${GITHUB_BRANCH}"
 
 # Install system dependencies including Chromium for Kaleido (ARM64 compatible)
@@ -172,8 +165,7 @@ RUN echo "=== VERIFYING SPAC INSTALLATION ===" && \
                print('new CPU path OK')" && \
     echo "Test 6: Verify UMAP compatibility with scikit-learn" && \
     python -c "import umap; import numpy as np; data = np.random.rand(100, 10); reducer = umap.UMAP(n_neighbors=5, min_dist=0.1); reducer.fit_transform(data); print(f'UMAP version: {umap.__version__} - OK')" && \
-    echo "=== ALL TESTS PASSED ===" || \
-    echo "Some import issues detected but proceeding"
+    echo "=== ALL TESTS PASSED ==="
 
 # Set working directory for Jupyter (will be mounted via volume)
 WORKDIR /workspace

--- a/tools/Dockerfile.gpu
+++ b/tools/Dockerfile.gpu
@@ -1,4 +1,4 @@
-# Dockerfile.v1.0.0 — nciccbr/spac-gpu:v1.0.0
+# Dockerfile.v1.0.1 — nciccbr/spac-gpu:v1.0.1
 #
 # SPAC GPU image for AWS Galaxy. Installs the grapheno GPU PhenoGraph
 # backend and the SPAC package on top of NVIDIA's RAPIDS 22.08 image
@@ -14,12 +14,12 @@
 # and the three GPU orchestration scripts are pulled from the same ref via
 # a shallow git clone. Everything stays pinned to GITHUB_BRANCH.
 #
-# For CCBR/Dockers2 CI (default): builds nciccbr/spac-gpu:v1.0.0 against
+# For CCBR/Dockers2 CI (default): builds nciccbr/spac-gpu:v1.0.1 against
 #   feature/phenograph-gpu-refactor. Bump GITHUB_BRANCH when SPAC is tagged.
 #
 # Manual local build example:
-#   docker build -f Dockerfile.v1.0.0 \
-#       -t nciccbr/spac-gpu:v1.0.0-test \
+#   docker build -f Dockerfile.v1.0.1 \
+#       -t nciccbr/spac-gpu:v1.0.1-test \
 #       --build-arg GITHUB_BRANCH=feature/phenograph-gpu-refactor \
 #       .
 #
@@ -83,7 +83,7 @@ ARG GITHUB_REPO=FNLCR-DMAP/SCSAWorkflow
 
 LABEL maintainer="FNLCR-DMAP"
 LABEL description="SPAC GPU image (grapheno PhenoGraph on RAPIDS 22.08) for AWS Galaxy"
-LABEL version="1.0.0"
+LABEL version="1.0.1"
 LABEL github.branch="${GITHUB_BRANCH}"
 LABEL rapids.version="22.08"
 

--- a/tools/galaxy_tools/phenograph_clustering_cpu.xml
+++ b/tools/galaxy_tools/phenograph_clustering_cpu.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" ?>
 <tool id="spac_phenograph_clustering_cpu"
       name="Phenograph Clustering CPU [SPAC] [DMAP]"
-      version="1.0.0"
+      version="1.0.1"
       profile="24.2">
     <description>Calculate automatic phenotypes using PhenoGraph on CPU. For datasets larger than ~500K cells, use the GPU tool instead.</description>
     <requirements>
-        <container type="docker">nciccbr/spac:v0.9.2</container>
+        <container type="docker">nciccbr/spac:v0.9.3</container>
     </requirements>
     <configfiles>
         <inputs name="params_json" filename="galaxy_params.json" data_style="paths"/>

--- a/tools/galaxy_tools/phenograph_clustering_gpu.xml
+++ b/tools/galaxy_tools/phenograph_clustering_gpu.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" ?>
 <tool id="spac_phenograph_clustering_gpu"
       name="Phenograph Clustering GPU [SPAC] [DMAP]"
-      version="1.0.0"
+      version="1.0.1"
       profile="24.2">
     <description>GPU-accelerated PhenoGraph clustering using RAPIDS (grapheno backend). For large datasets (&gt;~500K cells) where CPU is too slow.</description>
     <requirements>
-        <container type="docker">nciccbr/spac-gpu:v1.0.0</container>
+        <container type="docker">nciccbr/spac-gpu:v1.0.1</container>
     </requirements>
     <configfiles>
         <inputs name="params_json" filename="galaxy_params.json" data_style="paths"/>
@@ -14,7 +14,7 @@
 
 ## NOTE ON CONTAINER ARCHITECTURE
 ## ==============================================================
-## nciccbr/spac-gpu:v1.0.0 ships two conda envs because RAPIDS 22.08
+## nciccbr/spac-gpu:v1.0.1 ships two conda envs because RAPIDS 22.08
 ## pins numpy/pandas versions incompatible with anndata:
 ##
 ##   preprocess env  : anndata + pandas 1.5 + numpy 1.26
@@ -28,10 +28,7 @@
 ## ==============================================================
 
 echo '{"analysis": {"type": "file", "name": "output.pickle"}}' > outputs_config.json &&
-python '$__tool_directory__/format_values.py' 'galaxy_params.json' 'cleaned_params.json'
-    --bool-values Profiling
-    --list-values Resolution_List
-    --inject-outputs --outputs-config outputs_config.json &&
+python '$__tool_directory__/format_values.py' 'galaxy_params.json' 'cleaned_params.json' --bool-values Profiling --list-values Resolution_List --inject-outputs --outputs-config outputs_config.json &&
 bash /opt/spac-gpu/run_gpu.sh 'cleaned_params.json'
 
     ]]></command>

--- a/tools/spac_gpu/run_gpu.sh
+++ b/tools/spac_gpu/run_gpu.sh
@@ -24,7 +24,9 @@
 #   bash /opt/spac-gpu/run_gpu.sh <cleaned_params.json>
 # -----------------------------------------------------------------------------
 
-set -euo pipefail
+# Conda activation hooks in the RAPIDS image read GDAL/PROJ variables before
+# assigning them, so keep -u disabled while preserving exit and pipe failures.
+set -eo pipefail
 
 if [[ $# -ne 1 ]]; then
     echo "Usage: $0 <cleaned_params.json>" >&2


### PR DESCRIPTION
Fix PhenoGraph Galaxy runtime issues (https://github.com/FNLCR-DMAP/SCSAWorkflow/commit/12085e1a88902caa9cbe2d7e5a7c832bacb6106b)

- template_utils.py: defer anndata import to function bodies;
  rapids env does not ship anndata (Guillermo GPU error)
- cpu.py: wrap numpy communities in pd.Series before
  .astype('category') (Guillermo CPU error)
- run_gpu.sh: set -euo → set -eo; conda GDAL hooks read
  unbound vars (Biowulf validation)
- GPU XML: collapse format_values.py args to single line
- Add regression tests for cpu.py and template_utils lazy import